### PR TITLE
Fixes #43

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/envs/prod/Dockerfile
+++ b/{{cookiecutter.repostory_name}}/app/envs/prod/Dockerfile
@@ -41,6 +41,7 @@ ENV PATH=/root/.local/bin:$PATH
 COPY --from=base-image /root/ /root/
 
 {% if cookiecutter.use_alpine_linux == "y" -%}
+RUN apk add wget
 RUN grep psycopg2 requirements.txt && apk add --no-cache libpq || true
 RUN grep Pillow requirements.txt && apk add --no-cache jpeg tiff zlib libwebp || true
 {% endif -%}

--- a/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
+++ b/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
@@ -90,7 +90,7 @@ services:
   celery-flower:
     image: {{cookiecutter.django_project_name}}/app
     healthcheck:
-      test: wget -q --spider 0.0.0.0:80 || exit 1
+      test: wget --user ${CELERY_FLOWER_USER} --password ${CELERY_FLOWER_PASSWORD} -qO- 127.0.0.1:5555 > /dev/null || exit 1
     init: true
     restart: unless-stopped
     env_file: ./.env

--- a/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
+++ b/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       dockerfile: Dockerfile
     image: {{cookiecutter.django_project_name}}/app
     healthcheck:
-      test: wget -q 127.0.0.1:8000
+      test: wget -q --spider 127.0.0.1:8000/admin/login/ || exit 1
     init: true
     restart: unless-stopped
     env_file: ./.env
@@ -54,6 +54,8 @@ services:
   celery-worker:
     image: {{cookiecutter.django_project_name}}/app
     init: true
+    healthcheck:
+      test: celery -A {{cookiecutter.django_project_name}} status --quiet || exit 1
     restart: unless-stopped
     env_file: ./.env
     environment:
@@ -88,7 +90,7 @@ services:
   celery-flower:
     image: {{cookiecutter.django_project_name}}/app
     healthcheck:
-      test: wget -q 0.0.0.0:80
+      test: wget -q --spider 0.0.0.0:80 || exit 1
     init: true
     restart: unless-stopped
     env_file: ./.env
@@ -108,7 +110,7 @@ services:
     image: 'nginx:stable-alpine'
     restart: unless-stopped
     healthcheck:
-      test: wget -q 0.0.0.0:80
+      test: wget -q --spider 0.0.0.0:80/admin/login/ || exit 1
     environment:
       - NGINX_HOST=${NGINX_HOST}
     volumes:


### PR DESCRIPTION
* `|| exit 1` is needed because docker-compose says that exit code may be 0 (ok), 1 (error) or 2 (reserved).
* added celery healthcheck
* `--spider` makes HEAD request instead of GET