### PR TITLE
Add redirect 80->443 when use_https=y; clean up nginx https-related template

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,7 +4,6 @@
     "django_project_name": "project",
     "django_default_app_name": "core",
     "postgres_user": "postgres",
-    "use_https": "y",
     "use_celery": "y",
     "use_flower": "{% if cookiecutter.use_celery == 'y' %}y{% else %}n{% endif %}",
     "sentry_dsn": "",
@@ -27,6 +26,6 @@
     "csp_worker_src": "'self'",
     "csp_block_all_mixed_content": "y",
     "csp_exclude_url_prefixes": "",
-    "nginx_compression_enabled": "{% if cookiecutter.use_https == 'y' %}n{% else %}y{% endif %}",
+    "nginx_compression_enabled": "n",
     "use_alpine_linux": "y"
 }

--- a/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
+++ b/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
@@ -117,10 +117,8 @@ services:
       - ./nginx/templates:/etc/nginx/templates
       - backend-static:/srv/static:ro
       - ./media:/srv/media:ro
-      {% if cookiecutter.use_https == 'y' -%}
       - ./letsencrypt/etc:/etc/letsencrypt
       - ./letsencrypt/data:/data/letsencrypt
-      {% else -%}
       # uncomment for letsencrypt https
       # - ./letsencrypt/etc:/etc/letsencrypt
       # - ./letsencrypt/data:/data/letsencrypt
@@ -130,12 +128,7 @@ services:
     command: nginx -g 'daemon off;'
     ports:
       - 80:80
-      {% if cookiecutter.use_https == 'y' -%}
       - 443:443
-      {% else -%}
-      # uncomment for letsencrypt https
-      # - 443:443
-      {%- endif %}
     logging:
       <<: *logging
 

--- a/{{cookiecutter.repostory_name}}/letsencrypt_setup.sh
+++ b/{{cookiecutter.repostory_name}}/letsencrypt_setup.sh
@@ -19,9 +19,3 @@ docker run -it --rm \
 ./letsencrypt_setup_crontab.sh
 
 crontab -l
-
-{% if cookiecutter.use_https != 'y' %}
-echo ""
-echo "Project was generated without https configured."
-echo "Please remember to uncomment lines in envs/prod/docker-compose.yml and nginx/templates/default.conf.template"
-{% endif %}

--- a/{{cookiecutter.repostory_name}}/nginx/templates/default.conf.template
+++ b/{{cookiecutter.repostory_name}}/nginx/templates/default.conf.template
@@ -1,88 +1,79 @@
-{% if cookiecutter.use_https == 'y' %}
-    server {
-        listen 80;
-        rewrite ^/(.*)$ https://${NGINX_HOST}/$1 permanent;
-    }
-{% endif %}
+server {
+    listen 80;
+    rewrite ^/(.*)$ https://${NGINX_HOST}/$1 permanent;
+}
 
 server {
     server_name               ${NGINX_HOST};
 
-    {% if cookiecutter.use_https == 'y' %}
-        listen      443           ssl http2;
-        add_header                Strict-Transport-Security "max-age=31536000" always;
+    listen      443           ssl http2;
+    add_header                Strict-Transport-Security "max-age=31536000" always;
 
-        ssl_session_cache         shared:SSL:20m;
-        ssl_session_timeout       10m;
+    ssl_session_cache         shared:SSL:20m;
+    ssl_session_timeout       10m;
 
-        ssl_protocols             TLSv1.2 TLSv1.3;
-        ssl_prefer_server_ciphers on;
-        ssl_ciphers               "ECDH+AESGCM:ECDH+AES256:ECDH+AES128:!ADH:!AECDH:!MD5;";
+    ssl_protocols             TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers               "ECDH+AESGCM:ECDH+AES256:ECDH+AES128:!ADH:!AECDH:!MD5;";
 
-        ssl_stapling              on;
-        ssl_stapling_verify       on;
+    ssl_stapling              on;
+    ssl_stapling_verify       on;
 
-        ssl_certificate           /etc/letsencrypt/live/${NGINX_HOST}/fullchain.pem;
-        ssl_certificate_key       /etc/letsencrypt/live/${NGINX_HOST}/privkey.pem;
-        ssl_trusted_certificate   /etc/letsencrypt/live/${NGINX_HOST}/chain.pem;
+    ssl_certificate           /etc/letsencrypt/live/${NGINX_HOST}/fullchain.pem;
+    ssl_certificate_key       /etc/letsencrypt/live/${NGINX_HOST}/privkey.pem;
+    ssl_trusted_certificate   /etc/letsencrypt/live/${NGINX_HOST}/chain.pem;
 
-        resolver 8.8.8.8 8.8.4.4 valid=300s;
-        resolver_timeout 5s;
-    {% else %}
-        listen      80;
-    {% endif %}
+    resolver 8.8.8.8 8.8.4.4 valid=300s;
+    resolver_timeout 5s;
 
-    {% if cookiecutter.nginx_compression_enabled == 'y'%}
-        gzip on;
-        gzip_static on;
-        gzip_proxied any;
-        gzip_vary on;
-        gzip_comp_level 6;
-        gzip_buffers 16 8k;
-        gzip_http_version 1.1;
-        gzip_types
-            # text/html is always in gzip_types
-            text/richtext
-            text/plain
-            text/css
-            text/x-script
-            text/x-component
-            text/x-java-source
-            text/x-markdown
-            application/javascript
-            application/x-javascript
-            text/javascript
-            text/js
-            image/x-icon
-            application/x-perl
-            application/x-httpd-cgi
-            text/xml
-            application/xml
-            application/xml+rss
-            application/json
-            multipart/bag
-            multipart/mixed
-            application/xhtml+xml
-            font/ttf
-            font/otf
-            font/x-woff
-            image/svg+xml
-            application/vnd.ms-fontobject
-            application/ttf
-            application/x-ttf
-            application/otf
-            application/x-otf
-            application/truetype
-            application/opentype
-            application/x-opentype
-            application/font-woff
-            application/eot
-            application/font
-            application/font-sfnt
-            application/wasm;
-    {% else %}
-        gzip off;
-    {% endif %}
+
+    gzip {% if cookiecutter.nginx_compression_enabled == 'y'%}on{% else %}off{% endif %};
+    gzip_static {% if cookiecutter.nginx_compression_enabled == 'y'%}on{% else %}off{% endif %};
+    gzip_proxied {% if cookiecutter.nginx_compression_enabled == 'y'%}any{% else %}off{% endif %};
+    gzip_vary on;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+    gzip_types
+        # text/html is always in gzip_types
+        text/richtext
+        text/plain
+        text/css
+        text/x-script
+        text/x-component
+        text/x-java-source
+        text/x-markdown
+        application/javascript
+        application/x-javascript
+        text/javascript
+        text/js
+        image/x-icon
+        application/x-perl
+        application/x-httpd-cgi
+        text/xml
+        application/xml
+        application/xml+rss
+        application/json
+        multipart/bag
+        multipart/mixed
+        application/xhtml+xml
+        font/ttf
+        font/otf
+        font/x-woff
+        image/svg+xml
+        application/vnd.ms-fontobject
+        application/ttf
+        application/x-ttf
+        application/otf
+        application/x-otf
+        application/truetype
+        application/opentype
+        application/x-opentype
+        application/font-woff
+        application/eot
+        application/font
+        application/font-sfnt
+        application/wasm;
 
     access_log                /dev/stdout;
     error_log                 /dev/stderr info;
@@ -97,18 +88,11 @@ server {
         root /srv/;
     }
 
-{% if cookiecutter.use_https == 'y'%}
+
     location ^~ /.well-known {
         allow all;
         root  /data/letsencrypt/;
     }
-{% else %}
-    # uncomment for letsencrypt https
-    # location ^~ /.well-known {
-    #     allow all;
-    #     root  /data/letsencrypt/;
-    # }
-{% endif %}
 
     location / {
         proxy_pass_header Server;


### PR DESCRIPTION
This adds http -> https redirect; removed commented sections (we may always copy them from cookiecutter template when needed)