### PR TITLE
Run manage.py in standalone container

### DIFF
--- a/{{cookiecutter.repostory_name}}/bin/run-manage-py.sh
+++ b/{{cookiecutter.repostory_name}}/bin/run-manage-py.sh
@@ -2,4 +2,4 @@
 if [ "$(basename "$0")" == 'bin' ]; then
   cd ..
 fi
-docker-compose exec app sh -c "python manage.py $*"
+docker-compose run --rm app sh -c "python manage.py $*"

--- a/{{cookiecutter.repostory_name}}/bin/run-manage-py.sh
+++ b/{{cookiecutter.repostory_name}}/bin/run-manage-py.sh
@@ -2,4 +2,10 @@
 if [ "$(basename "$0")" == 'bin' ]; then
   cd ..
 fi
-docker-compose run --rm app sh -c "python manage.py $*"
+
+if [ "$1" = "detached" ]
+  then
+    docker-compose run --rm app sh -c "python manage.py ${@:2}"
+elif
+    docker-compose exec app sh -c "python manage.py $*"
+fi


### PR DESCRIPTION
Currently `run-manage-py.sh` command uses `docker-compose exec` to run `manage.py` in the same container where the app is running.
Proposed change runs command in a separate container, so the container inherits the same environment as running app, but does not interfere with any processes of the app and is not dismissed even during application redeployment - so long-running management command and shell sessions are not interrupted.