### PR TITLE
Include basic email setup

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
@@ -212,6 +212,15 @@ CELERY_WORKER_PREFETCH_MULTIPLIER = env.int('CELERY_WORKER_PREFETCH_MULTIPLIER',
 CELERY_BROKER_POOL_LIMIT = env.int('CELERY_BROKER_POOL_LIMIT', default=50)
 {% endif %}
 
+EMAIL_BACKEND = env('EMAIL_BACKEND', default='django.core.mail.backends.smtp.EmailBackend')
+EMAIL_FILE_PATH = env('EMAIL_FILE_PATH', default='')
+EMAIL_HOST = env('EMAIL_HOST', default='')
+EMAIL_PORT = env.int('EMAIL_PORT', default=587)
+EMAIL_HOST_USER = env('EMAIL_HOST_USER', default='')
+EMAIL_HOST_PASSWORD = env('EMAIL_HOST_PASSWORD', default='')
+EMAIL_USE_TLS = env.bool('EMAIL_USE_TLS', default=True)
+DEFAULT_FROM_EMAIL = env('DEFAULT_FROM_EMAIL', default=EMAIL_HOST_USER)
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,

--- a/{{cookiecutter.repostory_name}}/envs/dev/.env.template
+++ b/{{cookiecutter.repostory_name}}/envs/dev/.env.template
@@ -31,10 +31,14 @@ CELERY_FLOWER_PASSWORD=12345
 {% endif %}
 {% endif %}
 
-EMAIL_HOST=
-EMAIL_PORT=25
-EMAIL_HOST_USER=
+EMAIL_BACKEND=django.core.mail.backends.filebased.EmailBackend
+EMAIL_FILE_PATH=/tmp/email
+EMAIL_HOST=smtp.sendgrid.net
+EMAIL_PORT=587
+EMAIL_USE_TLS=1
+EMAIL_HOST_USER=apikey
 EMAIL_HOST_PASSWORD=
+DEFAULT_FROM_EMAIL=
 
 SENTRY_DSN={{cookiecutter.sentry_dsn}}
 

--- a/{{cookiecutter.repostory_name}}/envs/prod/.env.template
+++ b/{{cookiecutter.repostory_name}}/envs/prod/.env.template
@@ -31,10 +31,14 @@ CELERY_FLOWER_PASSWORD=
 {% endif %}
 {% endif %}
 
-EMAIL_HOST=
-EMAIL_PORT=25
-EMAIL_HOST_USER=
+EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+EMAIL_FILE_PATH=/tmp/email
+EMAIL_HOST=smtp.sendgrid.net
+EMAIL_PORT=587
+EMAIL_USE_TLS=1
+EMAIL_HOST_USER=apikey
 EMAIL_HOST_PASSWORD=
+DEFAULT_FROM_EMAIL=
 
 SENTRY_DSN={{cookiecutter.sentry_dsn}}
 


### PR DESCRIPTION
Currently there's no default email setup for our new projects - neither sendgrid, nor at least local filesystem backend.
This PR adds some env vars to make it easier to setup.