### PR TITLE
Separate sentry environment for different ENV variables

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
@@ -249,6 +249,7 @@ if SENTRY_DSN := env('SENTRY_DSN', default=''):
     from sentry_sdk.integrations.redis import RedisIntegration
     sentry_sdk.init(
         dsn=SENTRY_DSN,
+        environment=ENV,
         integrations=[
             DjangoIntegration(),
             CeleryIntegration(),

--- a/{{cookiecutter.repostory_name}}/envs/dev/.env.template
+++ b/{{cookiecutter.repostory_name}}/envs/dev/.env.template
@@ -1,4 +1,4 @@
-ENV=dev
+ENV=backend-dev
 DEBUG=on
 DEBUG_TOOLBAR=on
 SECRET_KEY=12345

--- a/{{cookiecutter.repostory_name}}/envs/prod/.env.template
+++ b/{{cookiecutter.repostory_name}}/envs/prod/.env.template
@@ -1,4 +1,4 @@
-ENV=prod
+ENV=backend-prod
 DEBUG=off
 DEBUG_TOOLBAR=off
 SECRET_KEY=


### PR DESCRIPTION
Using https://docs.sentry.io/product/sentry-basics/environments/
Because we want use different sentry environments for dev, staging and prod