### PR TITLE
Enable X-Forwarded-Proto header

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
@@ -88,6 +88,8 @@ if CORS_ENABLED := env.bool('CORS_ENABLED', default=True):
     CORS_ALLOWED_ORIGIN_REGEXES = env.list('CORS_ALLOWED_ORIGIN_REGEXES', default=[])
     CORS_ALLOW_ALL_ORIGINS = env.bool('CORS_ALLOW_ALL_ORIGINS', default=False)
 
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 # Content Security Policy
 if CSP_ENABLED := env.bool('CSP_ENABLED'):
     MIDDLEWARE.append('csp.middleware.CSPMiddleware')

--- a/{{cookiecutter.repostory_name}}/nginx/templates/default.conf.template
+++ b/{{cookiecutter.repostory_name}}/nginx/templates/default.conf.template
@@ -86,6 +86,7 @@ server {
         proxy_redirect off;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_pass http://app:8000/;
     }
 }


### PR DESCRIPTION
This change is required for django installations behind a reverse proxy, so that `request.is_secure()` works correctly: https://docs.djangoproject.com/en/4.0/ref/settings/#secure-proxy-ssl-header