### PR TITLE
Updated provider version, added health_check_type

### DIFF
--- a/{{cookiecutter.repostory_name}}/devops/tf/core/backend.tf
+++ b/{{cookiecutter.repostory_name}}/devops/tf/core/backend.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 

--- a/{{cookiecutter.repostory_name}}/devops/tf/main/envs/common/main.tf
+++ b/{{cookiecutter.repostory_name}}/devops/tf/main/envs/common/main.tf
@@ -66,4 +66,6 @@ module "admin" {
 
   azs         = module.networking.azs
   subnets     = module.networking.subnets
+
+  health_check_type = var.autoscaling_health_check_type
 }

--- a/{{cookiecutter.repostory_name}}/devops/tf/main/envs/common/vars.tf
+++ b/{{cookiecutter.repostory_name}}/devops/tf/main/envs/common/vars.tf
@@ -41,3 +41,8 @@ variable "domain_name" {
 variable "ec2_ssh_key" {
   type = string
 }
+
+variable "autoscaling_health_check_type" {
+  description = "either EC2 or ELB"
+  type = string
+}

--- a/{{cookiecutter.repostory_name}}/devops/tf/main/envs/common/versions.tf
+++ b/{{cookiecutter.repostory_name}}/devops/tf/main/envs/common/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 

--- a/{{cookiecutter.repostory_name}}/devops/tf/main/envs/prod/terraform.tfvars
+++ b/{{cookiecutter.repostory_name}}/devops/tf/main/envs/prod/terraform.tfvars
@@ -21,3 +21,8 @@ domain_name      = "{{ cookiecutter.aws_domain_name }}"
 
 # default ssh key
 ec2_ssh_key      = "{{ cookiecutter.aws_ec2_ssh_key }}"
+
+# defines if we use EC2-only healthcheck or ELB healthcheck
+# EC2 healthcheck reacts only on internal EC2 checks (i.e. if machine cannot be reached)
+# recommended for staging = EC@, for prod = ELB
+autoscaling_health_check_type = "ELB"

--- a/{{cookiecutter.repostory_name}}/devops/tf/main/envs/prod/terraform.tfvars
+++ b/{{cookiecutter.repostory_name}}/devops/tf/main/envs/prod/terraform.tfvars
@@ -24,5 +24,5 @@ ec2_ssh_key      = "{{ cookiecutter.aws_ec2_ssh_key }}"
 
 # defines if we use EC2-only healthcheck or ELB healthcheck
 # EC2 healthcheck reacts only on internal EC2 checks (i.e. if machine cannot be reached)
-# recommended for staging = EC@, for prod = ELB
+# recommended for staging = EC2, for prod = ELB
 autoscaling_health_check_type = "ELB"

--- a/{{cookiecutter.repostory_name}}/devops/tf/main/envs/staging/terraform.tfvars
+++ b/{{cookiecutter.repostory_name}}/devops/tf/main/envs/staging/terraform.tfvars
@@ -21,3 +21,8 @@ domain_name      = "{{ cookiecutter.aws_staging_domain_name }}"
 
 # default ssh key
 ec2_ssh_key      = "{{ cookiecutter.aws_ec2_ssh_key }}"
+
+# defines if we use EC2-only healthcheck or ELB healthcheck
+# EC2 healthcheck reacts only on internal EC2 checks (i.e. if machine cannot be reached)
+# recommended for staging = EC@, for prod = ELB
+autoscaling_health_check_type = "EC2"

--- a/{{cookiecutter.repostory_name}}/devops/tf/main/envs/staging/terraform.tfvars
+++ b/{{cookiecutter.repostory_name}}/devops/tf/main/envs/staging/terraform.tfvars
@@ -24,5 +24,5 @@ ec2_ssh_key      = "{{ cookiecutter.aws_ec2_ssh_key }}"
 
 # defines if we use EC2-only healthcheck or ELB healthcheck
 # EC2 healthcheck reacts only on internal EC2 checks (i.e. if machine cannot be reached)
-# recommended for staging = EC@, for prod = ELB
+# recommended for staging = EC2, for prod = ELB
 autoscaling_health_check_type = "EC2"

--- a/{{cookiecutter.repostory_name}}/devops/tf/main/modules/admin/ec2-autoscale.tf
+++ b/{{cookiecutter.repostory_name}}/devops/tf/main/modules/admin/ec2-autoscale.tf
@@ -111,4 +111,6 @@ resource "aws_autoscaling_group" "admin" {
   target_group_arns = [
     aws_lb_target_group.admin.arn
   ]
+
+  health_check_type = var.health_check_type
 }

--- a/{{cookiecutter.repostory_name}}/devops/tf/main/modules/admin/vars.tf
+++ b/{{cookiecutter.repostory_name}}/devops/tf/main/modules/admin/vars.tf
@@ -15,3 +15,5 @@ variable "ec2_ssh_key" {}
 
 variable "ecr_base_url" {}
 variable "ecr_image" {}
+
+variable "health_check_type" {}

--- a/{{cookiecutter.repostory_name}}/devops/tf/main/modules/database/rds.tf
+++ b/{{cookiecutter.repostory_name}}/devops/tf/main/modules/database/rds.tf
@@ -23,7 +23,7 @@ resource "aws_db_instance" "admin" {
   engine                 = "postgres"
   instance_class         = "db.t3.small"
   username               = "master"
-  name                   = "appdb"
+  db_name                = var.name
   password               = random_string.random.result
   skip_final_snapshot    = true
   availability_zone      = var.azs[0]


### PR DESCRIPTION
Changes:
1. updated aws provider to 4.x and removed deprecation (name -> db_name)
2. added health_check_type option to autoscaler

Now, we can use ELB health_check in autoscaler, which will enforce instance termination if ELB health check reports failure.