### PR TITLE
Only import debug_toolbar when needed

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/src/requirements.txt
+++ b/{{cookiecutter.repostory_name}}/app/src/requirements.txt
@@ -6,7 +6,7 @@ django-cors-headers==3.7.0
 django-environ==0.4.5
 django-extensions==3.1.3
 django-probes==1.6.0
-django-debug-toolbar==3.2.1
+django-debug-toolbar==3.5.0
 {% if cookiecutter.use_celery == "y" -%}
 celery==5.1.2
 {% if cookiecutter.use_flower == 'y' -%}

--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/urls.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/urls.py
@@ -11,7 +11,6 @@ urlpatterns = [
 ]
 
 if settings.DEBUG_TOOLBAR:
-    import debug_toolbar
     urlpatterns += [
-        path('__debug__/', include(debug_toolbar.urls)),
+        path('__debug__/', include('debug_toolbar.urls')),
     ]

--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/urls.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/urls.py
@@ -1,4 +1,3 @@
-import debug_toolbar
 from django.conf import settings
 from django.contrib.admin.sites import site
 from django.urls import include, path
@@ -12,6 +11,7 @@ urlpatterns = [
 ]
 
 if settings.DEBUG_TOOLBAR:
+    import debug_toolbar
     urlpatterns += [
         path('__debug__/', include(debug_toolbar.urls)),
     ]


### PR DESCRIPTION
`debug_toolbar` version 3.2.1 causes a memory leak in one of our projects. This leak happens even if the toolbar is never used, never added to `urlpatterns` and `DEBUG` is set to `False`. The import is enough.

Newer toolbar versions don't cause this particular problem, but I'm still making the import conditional just in case.

See:
https://github.com/vbaltrusaitis-reef/memleak-demo
https://github.com/jazzband/django-debug-toolbar/issues/906