### PR TITLE
Set up dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/{{cookiecutter.repostory_name}}/app/src"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/{{cookiecutter.repostory_name}}/app/envs/prod"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"

--- a/{{cookiecutter.repostory_name}}/.github/dependabot.yml
+++ b/{{cookiecutter.repostory_name}}/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/app/src"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/app/envs/prod"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This sets up dependabot both for cookiecutter project itself, and for all materialized projects as well.