### PR TITLE
Fix container healthchecks

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/envs/prod/Dockerfile
+++ b/{{cookiecutter.repostory_name}}/app/envs/prod/Dockerfile
@@ -36,6 +36,14 @@ RUN ENV=prod ENV_FILL_MISSING_VALUES=1 SECRET_KEY=dummy python3 manage.py collec
 FROM $BASE_IMAGE AS secondary-image
 LABEL builder=false
 
+{% if cookiecutter.use_alpine_linux == "y" -%}
+RUN apk add wget
+{%- else -%}
+RUN apt-get update \
+  && apt-get install -y wget \
+  && rm -rf /var/lib/apt/lists/*
+{%- endif %}
+
 WORKDIR /root/src/
 ENV PYTHONUNBUFFERED=1
 ENV PATH=/root/.local/bin:$PATH
@@ -43,10 +51,9 @@ ENV PATH=/root/.local/bin:$PATH
 COPY --from=base-image /root/ /root/
 
 {% if cookiecutter.use_alpine_linux == "y" -%}
-RUN apk add wget
 RUN grep psycopg2 requirements.txt && apk add --no-cache libpq || true
 RUN grep Pillow requirements.txt && apk add --no-cache jpeg tiff zlib libwebp || true
-{% endif -%}
+{%- endif %}
 
 EXPOSE 8000
 

--- a/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
+++ b/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
@@ -100,7 +100,7 @@ services:
   celery-flower:
     image: {{cookiecutter.django_project_name}}/app
     healthcheck:
-      test: wget --user ${CELERY_FLOWER_USER} --password ${CELERY_FLOWER_PASSWORD} -qO- 127.0.0.1:5555 > /dev/null || exit 1
+      test: wget --user "${CELERY_FLOWER_USER}" --password "${CELERY_FLOWER_PASSWORD}" -qO- 127.0.0.1:5555 > /dev/null || exit 1
     init: true
     restart: unless-stopped
     env_file: ./.env


### PR DESCRIPTION
Healthchecks for some of the containers didn't work because `wget` was
not installed -- this is now fixed.

This commit also moves the installation of wget (for both Alpine and
slim images) earlier in the Dockerfile for faster image rebuilds.