### PR TITLE
Prometheus metric files fix

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/envs/prod/Dockerfile
+++ b/{{cookiecutter.repostory_name}}/app/envs/prod/Dockerfile
@@ -28,6 +28,7 @@ COPY ./src/ /root/src/
 COPY ./envs/prod/entrypoint.sh /root/src/
 COPY ./envs/prod/gunicorn.conf.py /root/src/
 COPY ./envs/prod/celery-entrypoint.sh /root/src/
+COPY ./envs/prod/prometheus-cleanup.sh /root/src/
 
 RUN python3 -m compileall -b -f -q /root/
 RUN ENV=prod ENV_FILL_MISSING_VALUES=1 SECRET_KEY=dummy python3 manage.py collectstatic --no-input --clear

--- a/{{cookiecutter.repostory_name}}/app/envs/prod/celery-entrypoint.sh
+++ b/{{cookiecutter.repostory_name}}/app/envs/prod/celery-entrypoint.sh
@@ -15,4 +15,11 @@ nice celery multi start $WORKERS $OPTIONS \
     -Q:worker worker --autoscale:worker=$CELERY_WORKER_CONCURRENCY,0
 
 trap "celery multi stop $WORKERS $OPTIONS; exit 0" INT TERM
-tail -f /var/log/celery-*.log
+
+tail -f /var/log/celery-*.log &
+
+# check celery status periodically to exit if it crashed
+while true; do
+    sleep 30
+    celery -A {{cookiecutter.django_project_name}} status > /dev/null 2>&1 || exit 1
+done

--- a/{{cookiecutter.repostory_name}}/app/envs/prod/celery-entrypoint.sh
+++ b/{{cookiecutter.repostory_name}}/app/envs/prod/celery-entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -eu
 
+./prometheus-cleanup.sh
+
 # below we define two workers types (each may have any concurrency);
 # each worker may have its own settings
 WORKERS="master worker"

--- a/{{cookiecutter.repostory_name}}/app/envs/prod/entrypoint.sh
+++ b/{{cookiecutter.repostory_name}}/app/envs/prod/entrypoint.sh
@@ -2,7 +2,7 @@
 
 # We assume that WORKDIR is defined in Dockerfile
 
-{% if cookiecutter.monitoring == "y" %}[ "$PROMETHEUS_MULTIPROC_DIR" != "" -a -d "$PROMETHEUS_MULTIPROC_DIR" ] && rm -rf "$PROMETHEUS_MULTIPROC_DIR"/*{% endif %}
+./prometheus-cleanup.sh
 ./manage.py wait_for_database --timeout 10
 
 gunicorn -c gunicorn.conf.py

--- a/{{cookiecutter.repostory_name}}/app/envs/prod/prometheus-cleanup.sh
+++ b/{{cookiecutter.repostory_name}}/app/envs/prod/prometheus-cleanup.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+{% if cookiecutter.monitoring == "y" -%}
+set -e
+
+if [ -n "$PROMETHEUS_MULTIPROC_DIR" ]; then
+    if [ -d "$PROMETHEUS_MULTIPROC_DIR" ]; then
+        # Delete prometheus live metric files in PROMETHEUS_MULTIPROC_DIR, but not in its subdirectories to not
+        # interfere with other processes.  Note that this is equivalent to what multiprocess.mark_process_dead does,
+        # see https://github.com/prometheus/client_python/blob/master/prometheus_client/multiprocess.py#L159
+        find "$PROMETHEUS_MULTIPROC_DIR" -maxdepth 1 -type f -name 'gauge_live*_*.db' -delete
+    else
+        # Ensure the directory exists
+        mkdir -p "$PROMETHEUS_MULTIPROC_DIR"
+    fi
+fi
+{%- else -%}
+# No Prometheus clean up required as metrics are disabled.
+{%- endif %}

--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/celery.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/celery.py
@@ -2,6 +2,10 @@
 import os
 
 from celery import Celery
+{% if cookiecutter.monitoring == "y" %}
+from celery.signals import worker_process_shutdown
+from prometheus_client import multiprocess
+{% endif %}
 from django.conf import settings
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', '{{cookiecutter.django_project_name}}.settings')
@@ -14,6 +18,12 @@ app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 
 def route_task(name, args, kwargs, options, task=None, **kw):
     return {'queue': 'celery'}
+{% if cookiecutter.monitoring == "y" %}
+
+@worker_process_shutdown.connect
+def child_exit(pid, **kw):
+    multiprocess.mark_process_dead(pid)
+{% endif %}
 {% else %}
 # Use this as a starting point for your project with celery.
 # If you are not using celery, you can remove this app

--- a/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
+++ b/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
@@ -65,7 +65,7 @@ services:
     image: {{cookiecutter.django_project_name}}/app
     init: true
     healthcheck:
-      test: celery -A {{cookiecutter.django_project_name}} status --quiet || exit 1
+      test: celery -A {{cookiecutter.django_project_name}} status > /dev/null || exit 1
     restart: unless-stopped
     env_file: ./.env
     environment:

--- a/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
+++ b/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
@@ -72,7 +72,14 @@ services:
     env_file: ./.env
     environment:
       - DEBUG=off
+      {% if cookiecutter.monitoring == 'y' -%}
+      - PROMETHEUS_MULTIPROC_DIR=/prometheus-multiproc-dir/celery-worker
+      {%- endif %}
     command: ./celery-entrypoint.sh
+    {% if cookiecutter.monitoring == 'y' -%}
+    volumes:
+      - prometheus-metrics:/prometheus-multiproc-dir
+    {%- endif %}
     tmpfs: /run
     links:
       - redis:redis

--- a/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
+++ b/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
@@ -39,19 +39,21 @@ services:
     init: true
     restart: unless-stopped
     env_file: ./.env
-    {% if cookiecutter.monitoring == 'y' %}
-    environment:  # add this setting to any container that should dump prometheus metrics
+    {% if cookiecutter.monitoring == 'y' -%}
+    environment:
+      # Add this variable to all containers that should dump Prometheus metrics.  Each container besides this one
+      # should use a different subdirectory of /prometheus-multiproc-dir, e.g.
+      # - PROMETHEUS_MULTIPROC_DIR=/prometheus-multiproc-dir/other-container
+      # Don't forget to also mount the prometheus-metrics volume in other containers too.
       - PROMETHEUS_MULTIPROC_DIR=/prometheus-multiproc-dir
-    {% endif %}
+    {%- endif %}
     volumes:
       - backend-static:/root/src/static
       - ./media:/root/src/media
-      {% if cookiecutter.monitoring == 'y' %}
-      # If another container is using prometheus metrics, it should dump it's metrics to a subdirectory of the host dir,
-      # e.g `- ./prometheus-multiproc-dir/other_container:/prometheus-multiproc-dir` - all containers should use
-      # separate subdirs
-      - ./prometheus-multiproc-dir:/prometheus-multiproc-dir
-      {% endif %}
+      {% if cookiecutter.monitoring == 'y' -%}
+      # Add this mount to each container that should dump Prometheus metrics.
+      - prometheus-metrics:/prometheus-multiproc-dir
+      {%- endif %}
     links:
       - redis:redis
     depends_on:
@@ -185,3 +187,4 @@ services:
 
 volumes:
   backend-static:
+  prometheus-metrics:


### PR DESCRIPTION
This PR fixes clean ups of Prometheus metrics if they're used in celery workers. Workers, which exit will have their private live metrics removed.

Additionally fixes a few other issues are covered by this MR too:
* Fix for the health check command for the celery-worker container
* Fix for celery-worker container hanging running after celery crashes within the container
* Fix for races between containers related to cleaning up and accessing the metrics volume

See commit messages of individual commits for more details.