### PR TITLE
Single test ci fixes

### DIFF
--- a/{{cookiecutter.repostory_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.repostory_name}}/.github/workflows/ci.yml
@@ -54,10 +54,11 @@ jobs:
       - name: Install dependencies
         run: python -m pip install --upgrade nox pip setuptools
       - name: Run dockerized services
-        run: docker-compose up -d
+        run: docker compose up -d --wait
       - name: Run migrations
-        run: cd app/src && python manage.py wait_for_database --timeout 30 && python manage.py migrate
+        run: cd app/src && python manage.py wait_for_database --timeout 120 && python manage.py migrate
       - name: Run unit tests
         run: nox -vs test
       - name: Stop dockerized services
-        run: docker-compose down -v
+        if: success() || failure()
+        run: docker compose down -v

--- a/{{cookiecutter.repostory_name}}/noxfile.py
+++ b/{{cookiecutter.repostory_name}}/noxfile.py
@@ -75,7 +75,7 @@ def test(session):
             'pytest',
             '-W', 'ignore::DeprecationWarning', '-s', '-x', '-vv',
             '-n', 'auto',
-            'project',
+            '{{cookiecutter.django_project_name}}',
             *session.posargs,
             env={
                 'DJANGO_SETTINGS_MODULE': '{{cookiecutter.django_project_name}}.settings',


### PR DESCRIPTION
- CI: Ensuring that we wait for services to be healthy before we start other operations
- CI: Ensuring that the services are properly removed after the operation
- CI: Using `docker compose` instead of `docker-compose` (which is the recommended version https://www.docker.com/blog/announcing-compose-v2-general-availability/)
- Ensured that `noxfile` `test` points to a correct directory