### PR TITLE
Collect static files during deployment

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/envs/prod/Dockerfile
+++ b/{{cookiecutter.repostory_name}}/app/envs/prod/Dockerfile
@@ -31,7 +31,6 @@ COPY ./envs/prod/celery-entrypoint.sh /root/src/
 COPY ./envs/prod/prometheus-cleanup.sh /root/src/
 
 RUN python3 -m compileall -b -f -q /root/
-RUN ENV=prod ENV_FILL_MISSING_VALUES=1 SECRET_KEY=dummy python3 manage.py collectstatic --no-input --clear
 
 
 FROM $BASE_IMAGE AS secondary-image

--- a/{{cookiecutter.repostory_name}}/deploy.sh
+++ b/{{cookiecutter.repostory_name}}/deploy.sh
@@ -13,7 +13,7 @@ BASE_IMAGE=$(docker images --quiet --filter="label=builder=true" | head -n1)
 docker image tag ${BASE_IMAGE} {{cookiecutter.django_project_name}}/app-builder
 
 # collect static files to external storage while old app is still running
-# docker-compose run --rm app sh -c "python manage.py collectstatic --no-input"
+docker-compose run --rm app sh -c "python manage.py collectstatic --noinput"
 
 SERVICES=$(docker-compose ps --services 2>&1 > /dev/stderr \
            | grep -v -e 'is not set' -e nginx -e db -e redis)


### PR DESCRIPTION
During standard updating of frontend files and redeploying, I noticed that app was using old static files instead of new ones - until I manually ran `collectstatic` and restarted the app.

This happens because:
* we collect static files during image build; these files are "baked" into resulting docker image
* we have `backend_static` volume in docker-compose which is shared between `app` and `nginx` containers
* that `backend_static` volume is not available during image build, so static files inside it are not updated

Proposal:
* don't collect static files during image build
* collect static files during deployment - by running temporary instance of `app` and collecting files into `backend_static` volume