### PR TITLE
Fix docker-compose.yml: escape $

### DIFF
--- a/{{cookiecutter.repostory_name}}/devops/tf/main/files/docker-compose.yml
+++ b/{{cookiecutter.repostory_name}}/devops/tf/main/files/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       options:
         awslogs-region: ${region}
         awslogs-group: /aws/ec2/${name}-${env}
-        tag: '${INSTANCE_ID_SUBST}-app'
+        tag: '$${INSTANCE_ID_SUBST}-app'
         awslogs-create-group: "true"
 
   {% if cookiecutter.monitoring == 'y' %}


### PR DESCRIPTION
`INSTANCE_ID_SUBST` is a variable name for docker-compose, not a variable name for Terraform, `$` needs to be escaped here. This is done correctly in line 97.