### PR TITLE
Enable 0-RTT (TLS 1.3 Early Data) in Nginx

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -29,6 +29,7 @@
     "csp_exclude_url_prefixes": "",
     "nginx_redirect_www_prefix": "y",
     "nginx_compression_enabled": "n",
+    "nginx_early_data_enabled": "n",
     "use_alpine_linux": "n",
     "aws_use_packer": "n",
     "aws_project_name": "{{ cookiecutter.repostory_name }}",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -29,7 +29,7 @@
     "csp_exclude_url_prefixes": "",
     "nginx_redirect_www_prefix": "y",
     "nginx_compression_enabled": "n",
-    "nginx_early_data_enabled": "n",
+    "nginx_tls_early_data_enabled": "n",
     "use_alpine_linux": "n",
     "aws_use_packer": "n",
     "aws_project_name": "{{ cookiecutter.repostory_name }}",

--- a/{{cookiecutter.repostory_name}}/devops/tf/main/files/docker-compose.yml
+++ b/{{cookiecutter.repostory_name}}/devops/tf/main/files/docker-compose.yml
@@ -65,7 +65,7 @@ services:
   {% endif %}
 
   nginx:
-    image: 'ghcr.io/reef-technologies/nginx-rt:v1.1.0'
+    image: 'ghcr.io/reef-technologies/nginx-rt:v1.2.0'
     restart: unless-stopped
     healthcheck:
       test: wget -q --spider http://0.0.0.0/admin/login || exit 1

--- a/{{cookiecutter.repostory_name}}/devops/tf/main/files/nginx/templates/default.conf.template
+++ b/{{cookiecutter.repostory_name}}/devops/tf/main/files/nginx/templates/default.conf.template
@@ -30,16 +30,24 @@ server {
     {% endif %}
 
     location / {
+        {% if cookiecutter.nginx_tls_early_data_enabled == 'y' -%}
+        if ($too_early) {
+            return 425;
+        }
+        {%- endif %}
         proxy_pass_header Server;
         proxy_redirect off;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_pass_header X-Forwarded-Proto;
+        {% if cookiecutter.nginx_tls_early_data_enabled == 'y' -%}
+        proxy_set_header Early-Data $ssl_early_data;
+        {%- endif %}
         proxy_pass http://app:8000/;
     }
 }
 
-{% if cookiecutter.monitoring == 'y' %}
+{% if cookiecutter.monitoring == 'y' -%}
 upstream node_exporter {
     server host.docker.internal:9100;
 }
@@ -103,4 +111,14 @@ server {
     }
 
 }
-{% endif %}
+{%- endif %}
+
+{% if cookiecutter.nginx_tls_early_data_enabled == 'y' -%}
+ssl_early_data on;
+
+map "$request_method:$ssl_early_data" $too_early {
+    default   1;
+    "GET:1"   0;
+    "~^\S+:$" 0;
+}
+{%- endif %}

--- a/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
+++ b/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
@@ -120,7 +120,7 @@ services:
   {% endif -%}
 
   nginx:
-    image: 'ghcr.io/reef-technologies/nginx-rt:v1.1.0'
+    image: 'ghcr.io/reef-technologies/nginx-rt:v1.2.0'
     restart: unless-stopped
     healthcheck:
       test: wget -q --spider 0.0.0.0:80 || exit 1

--- a/{{cookiecutter.repostory_name}}/nginx/templates/default.conf.template
+++ b/{{cookiecutter.repostory_name}}/nginx/templates/default.conf.template
@@ -34,7 +34,7 @@ server {
     return 444;
 }
 
-{% if cookiecutter.nginx_redirect_www_prefix == 'y' %}
+{% if cookiecutter.nginx_redirect_www_prefix == 'y' -%}
 server {
     listen 443 ssl;
     server_name www.${NGINX_HOST};
@@ -48,7 +48,7 @@ server {
 
     return 301 https://${NGINX_HOST}$request_uri;
 }
-{% endif %}
+{%- endif %}
 
 server {
     listen                    443 ssl http2;
@@ -89,16 +89,24 @@ server {
     {% endif %}
 
     location / {
+        {% if cookiecutter.nginx_early_data_enabled == 'y' -%}
+        if ($too_early) {
+            return 425;
+        }
+        {%- endif %}
         proxy_pass_header Server;
         proxy_redirect off;
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
+        {% if cookiecutter.nginx_early_data_enabled == 'y' -%}
+        proxy_set_header Early-Data $ssl_early_data;
+        {%- endif %}
         proxy_pass http://app:8000/;
     }
 }
 
-{% if cookiecutter.monitoring == 'y' %}
+{% if cookiecutter.monitoring == 'y' -%}
 upstream node_exporter {
     server host.docker.internal:9100;
 }
@@ -153,4 +161,14 @@ server {
     }
 
 }
-{% endif %}
+{%- endif %}
+
+{% if cookiecutter.nginx_early_data_enabled == 'y' -%}
+ssl_early_data on;
+
+map "$request_method:$ssl_early_data" $too_early {
+    default   1;
+    "GET:1"   0;
+    "~^\S+:$" 0;
+}
+{%- endif %}

--- a/{{cookiecutter.repostory_name}}/nginx/templates/default.conf.template
+++ b/{{cookiecutter.repostory_name}}/nginx/templates/default.conf.template
@@ -89,7 +89,7 @@ server {
     {% endif %}
 
     location / {
-        {% if cookiecutter.nginx_early_data_enabled == 'y' -%}
+        {% if cookiecutter.nginx_tls_early_data_enabled == 'y' -%}
         if ($too_early) {
             return 425;
         }
@@ -99,7 +99,7 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
-        {% if cookiecutter.nginx_early_data_enabled == 'y' -%}
+        {% if cookiecutter.nginx_tls_early_data_enabled == 'y' -%}
         proxy_set_header Early-Data $ssl_early_data;
         {%- endif %}
         proxy_pass http://app:8000/;
@@ -163,7 +163,7 @@ server {
 }
 {%- endif %}
 
-{% if cookiecutter.nginx_early_data_enabled == 'y' -%}
+{% if cookiecutter.nginx_tls_early_data_enabled == 'y' -%}
 ssl_early_data on;
 
 map "$request_method:$ssl_early_data" $too_early {


### PR DESCRIPTION
Tested with:
1. openssl
    * GET
    ```bash
    $ echo -e "GET /admin/login HTTP/1.1\r\nHost: $host\r\nConnection: close\r\n\r\n" > request.txt
    $ openssl s_client -connect $host:443 -tls1_3 -sess_out session.pem -ign_eof < request.txt
    ...
    $ openssl s_client -connect $host:443 -tls1_3 -sess_in session.pem -early_data request.txt
    ...
    
    subject=CN = app.lan.mlit.pro
    issuer=C = US, O = Let's Encrypt, CN = R3
    ---
    No client certificate CA names sent
    Server Temp Key: X25519, 253 bits
    ---
    SSL handshake has read 261 bytes and written 550 bytes
    Verification: OK
    ---
    Reused, TLSv1.3, Cipher is TLS_AES_256_GCM_SHA384
    Server public key is 2048 bit
    Secure Renegotiation IS NOT supported
    Compression: NONE
    Expansion: NONE
    No ALPN negotiated
    Early data was accepted
    Verify return code: 0 (ok)
    ---
    HTTP/1.1 302 Found
    Date: Sun, 21 May 2023 14:51:55 GMT
    Content-Type: text/html; charset=utf-8
    Content-Length: 0
    Connection: close
    Server: gunicorn
    Location: /admin/login/?next=/admin/login
    Expires: Sun, 21 May 2023 14:51:55 GMT
    Cache-Control: max-age=0, no-cache, no-store, must-revalidate, private
    X-Frame-Options: DENY
    Vary: Cookie, Origin
    X-Content-Type-Options: nosniff
    Referrer-Policy: same-origin
    Strict-Transport-Security: max-age=31536000
    X-Content-Type-Options: nosniff
    X-XSS-Protection: 1; mode=block
    X-Frame-Options: DENY
    
    closed
    ```
    * POST
    ```bash
    $ echo -e "POST /admin/login HTTP/1.1\r\nHost: $host\r\nConnection: close\r\n\r\n" > request.txt
    $ openssl s_client -connect $host:443 -tls1_3 -sess_out session.pem -ign_eof < request.txt
    ...
    $ openssl s_client -connect $host:443 -tls1_3 -sess_in session.pem -early_data request.txt
    ...
    
    subject=CN = app.lan.mlit.pro
    issuer=C = US, O = Let's Encrypt, CN = R3
    ---
    No client certificate CA names sent
    Server Temp Key: X25519, 253 bits
    ---
    SSL handshake has read 261 bytes and written 551 bytes
    Verification: OK
    ---
    Reused, TLSv1.3, Cipher is TLS_AES_256_GCM_SHA384
    Server public key is 2048 bit
    Secure Renegotiation IS NOT supported
    Compression: NONE
    Expansion: NONE
    No ALPN negotiated
    Early data was accepted
    Verify return code: 0 (ok)
    ---
    HTTP/1.1 425 
    Server: nginx
    Date: Sun, 21 May 2023 14:43:38 GMT
    Content-Length: 0
    Connection: close
    Strict-Transport-Security: max-age=31536000
    
    closed
    ```

3. sslyze
    ```bash
    $ python -m sslyze --early_data "app.lan.mlit.pro"
    
     CHECKING CONNECTIVITY TO SERVER(S)
     ----------------------------------
    
       app.lan.mlit.pro:443      => 192.168.0.195 
    
    
     SCAN RESULTS FOR APP.LAN.MLIT.PRO:443 - 192.168.0.195
     -----------------------------------------------------
    
     * TLS 1.3 Early Data:
                                              Suppported - Server accepted early data
    
     SCANS COMPLETED IN 0.211804 S
     -----------------------------
    ```