### PR TITLE
updated Django to 4.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,3 +20,6 @@ nox
 ```
 
 to check if everything is OK.
+
+Denote any breaking changes in [CHANGELOG.md]({{cookiecutter.repostory_name}}/docs/3rd_party/cookiecutter-rt-django/CHANGELOG.md).
+When updating dependencies that has breaking changes add a link to the changelog of the dependency prepend the entry with `**BREAKING**` tag.

--- a/README.md
+++ b/README.md
@@ -14,14 +14,18 @@ pip install cruft
   ```sh
   cruft create https://github.com/reef-technologies/cookiecutter-rt-django
   ```
+
 - See diff with
   ```sh
   cruft diff
   ```
+
 - Update the project by running
   ```sh
   cruft update
   ```
+  Before commiting make sure to review changes listed in `docs/3rd_party/cookiecutter-rt-django/CHANGELOG.md`.
+
 - If you have a repo which was initialized without cruft (i.e. with `cookiecutter` command), you can still link the project:
   ```sh
   cruft link https://github.com/reef-technologies/cookiecutter-rt-django
@@ -33,3 +37,7 @@ More on cruft:
 ## License
 
 This project is licensed under the terms of the [BSD-3 License](/LICENSE)
+
+## Changelog
+
+Breaking changes are documented in the [CHANGELOG]({{cookiecutter.repostory_name}}/docs/3rd_party/cookiecutter-rt-django/CHANGELOG.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,10 @@ dependencies = [
     "nox",
 ]
 
+[project.urls]
+homepage = "https://github.com/reef-technologies/cookiecutter-rt-django"
+changelog = "https://github.com/reef-technologies/cookiecutter-rt-django/{{cookiecutter.repostory_name}}/docs/3rd_party/cookiecutter-rt-django/CHANGELOG.md"
+
 [tool.setuptools]
 packages = []
 

--- a/{{cookiecutter.repostory_name}}/app/src/pytest.ini
+++ b/{{cookiecutter.repostory_name}}/app/src/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 python_files = tests.py test_*.py *_tests.py
+
+[pytest.ini_options]
+DJANGO_SETTINGS_MODULE = "{{cookiecutter.django_project_name}}.{{cookiecutter.django_default_app_name}}.tests.settings"

--- a/{{cookiecutter.repostory_name}}/app/src/requirements.txt
+++ b/{{cookiecutter.repostory_name}}/app/src/requirements.txt
@@ -1,25 +1,25 @@
-Django==3.2.12
+Django==4.2.2
 {% if cookiecutter.csp_enabled == "y" -%}
 django-csp==3.7
 {% endif -%}
-django-cors-headers==3.7.0
+django-cors-headers==4.0.0
 django-environ==0.4.5
-django-extensions==3.1.3
+django-extensions==3.2.3
 django-probes==1.6.0
-django-debug-toolbar==3.5.0
+django-debug-toolbar==4.1.0
 {% if cookiecutter.use_celery == "y" -%}
 celery==5.1.2
 {% if cookiecutter.use_flower == 'y' -%}
 flower==1.0.0
 {% endif -%}
 {% endif -%}
-psycopg2-binary==2.9.1
+psycopg2-binary==2.9.6
 redis==3.5.3
-sentry-sdk==1.3.0
+sentry-sdk==1.25.1
 ipython==7.26.0
-nox==2022.8.7
+nox==2023.4.22
 {% if cookiecutter.monitoring == "y" %}
-prometheus-client~=0.13.0
-django-prometheus==2.2.0
-django-business-metrics==0.1.0
+prometheus-client~=0.17.0
+django-prometheus==2.3.1
+django-business-metrics==1.0.0
 {% endif %}

--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
@@ -68,6 +68,9 @@ INSTALLED_APPS = [
     '{{cookiecutter.django_project_name}}.{{cookiecutter.django_default_app_name}}',
 ]
 
+{%- if cookiecutter.monitoring == "y" %}
+PROMETHEUS_EXPORT_MIGRATIONS = True
+{%- endif %}
 {%- if cookiecutter.monitor_view_execution_time_in_djagno == "y" and cookiecutter.monitoring == "y" %}
 PROMETHEUS_LATENCY_BUCKETS = (.008, .016, .032, .062, .125, .25, .5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, float("inf"))
 {%- endif %}

--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/tests/settings.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/tests/settings.py
@@ -1,0 +1,6 @@
+from {{cookiecutter.django_project_name}}.settings import *  # noqa: F403
+
+DEBUG_TOOLBAR = False
+{%- if cookiecutter.monitoring == "y" %}
+PROMETHEUS_EXPORT_MIGRATIONS = False
+{%- endif %}

--- a/{{cookiecutter.repostory_name}}/docs/3rd_party/cookiecutter-rt-django/CHANGELOG.md
+++ b/{{cookiecutter.repostory_name}}/docs/3rd_party/cookiecutter-rt-django/CHANGELOG.md
@@ -1,0 +1,17 @@
+# cookiecutter-rt-django Changelog
+
+Main purpose of this file is to provide a changelog for the template itself.
+It is not intended to be used as a changelog for the generated project.
+
+This changelog will document any know **BREAKING** changes between versions of the template.
+Please review this new entries carefully after applying `cruft update` before committing the changes.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+Currently, `cookiecutter-rt-django` has no explicit versioning amd we purely rely on `cruft` diff.
+
+## [Unreleased]
+
+* **BREAKING** Updated Django from 3.2 to 4.2 (https://docs.djangoproject.com/en/4.2/releases/4.0/#backwards-incompatible-changes-in-4-0)
+* **BREAKING** Updated django-cors-headers from 3.7 to 4.0 (https://github.com/adamchainz/django-cors-headers/blob/main/CHANGELOG.rst#400-2023-05-12)
+* **BREAKING** Updated django-environ from 0.7 to 0.10 (https://django-environ.readthedocs.io/en/latest/changelog.html)

--- a/{{cookiecutter.repostory_name}}/noxfile.py
+++ b/{{cookiecutter.repostory_name}}/noxfile.py
@@ -89,8 +89,4 @@ def test(session):
             '-n', 'auto',
             '{{cookiecutter.django_project_name}}',
             *session.posargs,
-            env={
-                'DJANGO_SETTINGS_MODULE': '{{cookiecutter.django_project_name}}.settings',
-                'DEBUG_TOOLBAR': '0',
-            },
         )


### PR DESCRIPTION
* add Changelog to document breakages - when someone does `cruft update` they will have to go thru these one-by-one for their project in each project - so putting links to the changelogs saves time for everyone doing that chore
* updated Django and other more or less related deps
* dedicated tests settings added - so since some settings have to be customized for tests only ( for example https://github.com/korfuri/django-prometheus/issues/281 )