### PR TITLE
Add `*.egg-info/` to `.gitingore`

### DIFF
--- a/{{cookiecutter.repostory_name}}/.gitignore
+++ b/{{cookiecutter.repostory_name}}/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *.sqlite3
 *~
+*.egg-info/
 /docker-compose.yml
 /.idea/
 /redis/


### PR DESCRIPTION
Add `*.egg-info/` to `.gitingore` so that projects do not accidentally add this directory in git repositories.