### PR TITLE
Update deps & limit dependabot to security updates only

### DIFF
--- a/{{cookiecutter.repostory_name}}/.github/dependabot.yml
+++ b/{{cookiecutter.repostory_name}}/.github/dependabot.yml
@@ -4,7 +4,9 @@ updates:
     directory: "/app/src"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
   - package-ecosystem: "docker"
     directory: "/app/envs/prod"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0

--- a/{{cookiecutter.repostory_name}}/app/src/requirements.txt
+++ b/{{cookiecutter.repostory_name}}/app/src/requirements.txt
@@ -1,22 +1,22 @@
-Django==4.2.2
+Django~=4.2.4
 {% if cookiecutter.csp_enabled == "y" -%}
 django-csp==3.7
 {% endif -%}
-django-cors-headers==4.0.0
-django-environ==0.4.5
+django-cors-headers~=4.2.0
+django-environ~=0.10.0
 django-extensions==3.2.3
 django-probes==1.7.0
 django-debug-toolbar==4.1.0
 {% if cookiecutter.use_celery == "y" -%}
-celery==5.1.2
+celery~=5.3.1
 {% if cookiecutter.use_flower == 'y' -%}
-flower==1.0.0
+flower~=2.0.0
 {% endif -%}
 {% endif -%}
-psycopg2-binary==2.9.6
-redis==3.5.3
-sentry-sdk==1.25.1
-ipython==7.26.0
+psycopg2-binary~=2.9.7
+redis~=4.6.0
+sentry-sdk==1.29.2
+ipython~=8.14.0
 nox==2023.4.22
 {% if cookiecutter.monitoring == "y" %}
 prometheus-client~=0.17.0

--- a/{{cookiecutter.repostory_name}}/docs/3rd_party/cookiecutter-rt-django/CHANGELOG.md
+++ b/{{cookiecutter.repostory_name}}/docs/3rd_party/cookiecutter-rt-django/CHANGELOG.md
@@ -12,6 +12,8 @@ Currently, `cookiecutter-rt-django` has no explicit versioning amd we purely rel
 
 ## [Unreleased]
 
+* **BREAKING** Updated django-environ from 0.4.5 to 0.10 (https://django-environ.readthedocs.io/en/latest/changelog.html)
+* **BREAKING** Updated redis python package from 3.5.3 to 4.6 (breaking changes listed in https://github.com/redis/redis-py/releases/tag/v4.0.0b1)
 * **BREAKING** Updated Python from 3.9 to 3.11
 * **BREAKING** Updated Django from 3.2 to 4.2 (https://docs.djangoproject.com/en/4.2/releases/4.0/#backwards-incompatible-changes-in-4-0)
 * **BREAKING** Updated django-cors-headers from 3.7 to 4.0 (https://github.com/adamchainz/django-cors-headers/blob/main/CHANGELOG.rst#400-2023-05-12)


### PR DESCRIPTION
so dependabot was bothering me with multiple PRs updating the same things; this PR will update most of them & limit dependabot to security updates only