### PR TITLE
disable buildkit in non cloud deployment

### DIFF
--- a/{{cookiecutter.repostory_name}}/deploy.sh
+++ b/{{cookiecutter.repostory_name}}/deploy.sh
@@ -6,7 +6,7 @@ if [ ! -f ".env" ]; then
     exit 1;
 fi
 
-docker-compose build
+DOCKER_BUILDKIT=0 docker-compose build
 
 # Tag the first image from multi-stage app Dockerfile to mark it as not dangling
 BASE_IMAGE=$(docker images --quiet --filter="label=builder=true" | head -n1)


### PR DESCRIPTION
with buildkit on, I was getting an error in stages after `docker-compose build`, because the image with label `builder=true` was not saved after `docker-compose build`. The setup was:

```
docker -v
Docker version 24.0.5, build ced0996

docker-compose -v
docker-compose version 1.29.2, build unknown

uname -a
Linux vps-30653377 5.15.0-78-generic #85-Ubuntu SMP Fri Jul 7 15:25:09 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
```

