### PR TITLE
fix git hook creating, set git default branch explicitly

### DIFF
--- a/{{cookiecutter.repostory_name}}/README.md
+++ b/{{cookiecutter.repostory_name}}/README.md
@@ -56,7 +56,7 @@ Use `ssh-keygen` to generate a key pair for the server, then add read-only acces
 cd ~
 mkdir repos
 cd repos
-git init --bare {{ cookiecutter.repostory_name }}.git
+git init --bare --default-branch=master {{ cookiecutter.repostory_name }}.git
 
 cd ~
 mkdir domains
@@ -74,7 +74,7 @@ git push production master
 # remote server
 cd ~/repos/{{ cookiecutter.repostory_name }}.git
 
-cat <<EOT >> hooks/post-receive
+cat <<'EOT' > hooks/post-receive
 #!/bin/bash
 unset GIT_INDEX_FILE
 export ROOT=/root

--- a/{{cookiecutter.repostory_name}}/README.md
+++ b/{{cookiecutter.repostory_name}}/README.md
@@ -56,7 +56,7 @@ Use `ssh-keygen` to generate a key pair for the server, then add read-only acces
 cd ~
 mkdir repos
 cd repos
-git init --bare --default-branch=master {{ cookiecutter.repostory_name }}.git
+git init --bare --initial-branch=master {{ cookiecutter.repostory_name }}.git
 
 cd ~
 mkdir domains

--- a/{{cookiecutter.repostory_name}}/setup-dev.sh
+++ b/{{cookiecutter.repostory_name}}/setup-dev.sh
@@ -3,6 +3,7 @@
 
 PROJECT_DIR=`cd "$(dirname "${BASH_SOURCE[0]}")" && pwd`
 ENV_DIR="./envs/dev"
+cd ${PROJECT_DIR}
 
 # Check if we are inside virtualenv or CI
 [[ ! -z $VIRTUAL_ENV || ! -z $CI ]] || { echo -e "\e[31mYou must run this script inside virtualenv!\e[0m"; exit 1; }
@@ -19,7 +20,7 @@ pip install --upgrade -r "${PROJECT_DIR}/app/src/requirements.txt"
 # Set symlinks
 ln -sf "${ENV_DIR}/.env" .env
 ln -sf "${ENV_DIR}/docker-compose.yml" docker-compose.yml
-cd app
+cd "${PROJECT_DIR}/app/"
 [[ -L "Dockerfile" ]] && unlink Dockerfile
 [[ -L "src/entrypoint.sh" ]] && unlink src/entrypoint.sh
 

--- a/{{cookiecutter.repostory_name}}/setup-prod.sh
+++ b/{{cookiecutter.repostory_name}}/setup-prod.sh
@@ -3,6 +3,7 @@
 
 PROJECT_DIR=`cd "$(dirname "${BASH_SOURCE[0]}")" && pwd`
 ENV_DIR="./envs/prod"
+cd ${PROJECT_DIR}
 
 # Create .env from the template if doesn't exist
 [[ -f "${ENV_DIR}/.env" ]] || cp "${ENV_DIR}/.env.template" "${ENV_DIR}/.env"
@@ -10,6 +11,6 @@ ENV_DIR="./envs/prod"
 # Set symlinks
 ln -sf "${ENV_DIR}/.env" .env
 ln -sf "${ENV_DIR}/docker-compose.yml" docker-compose.yml
-cd app
+cd "${PROJECT_DIR}/app/"
 ln -sf "${ENV_DIR}/Dockerfile" Dockerfile
 ln -sf ".${ENV_DIR}/entrypoint.sh" src/entrypoint.sh


### PR DESCRIPTION
- set default branch in `git init` explicitly
- fix heredoc for git hook
- fix running `setup-prod.sh`/`setup-dev.sh` from different directories than where the script lives (eg. when executing it via `cloud-init` on Vultr)