### PR TITLE
increase db connection reliability when working with pgbouncer

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/src/requirements.txt
+++ b/{{cookiecutter.repostory_name}}/app/src/requirements.txt
@@ -6,6 +6,7 @@ django-cors-headers~=4.2.0
 django-environ~=0.10.0
 django-extensions==3.2.3
 django-probes==1.7.0
+django-dbconn-retry==0.1.7
 django-debug-toolbar==4.1.0
 {% if cookiecutter.use_celery == "y" -%}
 celery~=5.3.1

--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
@@ -52,6 +52,7 @@ DEBUG = env('DEBUG')
 ALLOWED_HOSTS = ['*']
 
 INSTALLED_APPS = [
+    "django_dbconn_retry",
     {%- if cookiecutter.monitoring == "y" %}
     'django_prometheus',
     {%- endif %}


### PR DESCRIPTION
to be consider:
disabling DB-side cursors; they should be disabled with transaction based pgbouncer pooling anyhow and they will break on reconnection

this fixed OperationError that happens sometimes with pgbouncer (especially if it has some proxy in front of it).
Fixed issues when working with Vultr postgresql db.