### PR TITLE
allow for local running of spellchecker

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip install cruft
   ```sh
   cruft update
   ```
-  Before commiting make sure to review changes listed in `docs/3rd_party/cookiecutter-rt-django/CHANGELOG.md`.
+  Before committing make sure to review changes listed in `docs/3rd_party/cookiecutter-rt-django/CHANGELOG.md`.
 
 - If you have a repo which was initialized without cruft (i.e. with `cookiecutter` command), you can still link the project:
   ```sh

--- a/noxfile.py
+++ b/noxfile.py
@@ -54,6 +54,7 @@ def lint(session):
     """Run linters in readonly mode."""
     session.run('pip', 'install', '-e', '.[lint]')
     session.run('ruff', 'check', '--diff', '.')
+    session.run('codespell', '.')
     run_readable(session, mode="check")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ packages = []
 
 [project.optional-dependencies]
 format = ["ruff"]
-lint = ["ruff"]
+lint = ["ruff", "codespell[toml]"]
 
 [tool.ruff]
 # TODO add D
@@ -38,3 +38,7 @@ exclude = [
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]
 "test/**" = ["D", "F403", "F405"]
+
+[tool.codespell]
+skip = '*.min.js'
+ignore-words-list = 'datas'

--- a/{{cookiecutter.repostory_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.repostory_name}}/.github/workflows/ci.yml
@@ -8,18 +8,6 @@ env:
   PYTHON_DEFAULT_VERSION: "3.11"
 
 jobs:
-{%- if cookiecutter.ci_use_spellchecker == "y" %}
-  spellchecker:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Check spelling
-        uses: codespell-project/actions-codespell@2391250ab05295bddd51e36a8c6295edb6343b0e
-        with:
-          ignore_words_list: datas
-{%- endif %}
 {%- if cookiecutter.ci_use_linter == "y" %}
   linter:
     runs-on: ubuntu-latest

--- a/{{cookiecutter.repostory_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.repostory_name}}/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Run linter and tests on pull requests
+name: Run linter and tests
 
 on:
   push:

--- a/{{cookiecutter.repostory_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.repostory_name}}/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: Run linter and tests on pull requests
 
 on:
+  push:
+    branches: [master, main]
   pull_request:
     branches: [master, main]
 

--- a/{{cookiecutter.repostory_name}}/noxfile.py
+++ b/{{cookiecutter.repostory_name}}/noxfile.py
@@ -43,6 +43,9 @@ def format_(session):
 def lint(session):
     session.run('pip', 'install', '-e', '.[lint]')
     session.run('ruff', 'check', '--diff', '.')
+{%- if cookiecutter.ci_use_spellchecker == "y" %}
+    session.run('codespell', '.')
+{%- endif %}
     run_readable(session, mode="check")
 
 

--- a/{{cookiecutter.repostory_name}}/pyproject.toml
+++ b/{{cookiecutter.repostory_name}}/pyproject.toml
@@ -10,7 +10,12 @@ dependencies = { file = ["app/src/requirements.txt"] }
 
 [project.optional-dependencies]
 format = ["ruff"]
-lint = ["ruff"]
+lint = [
+    "ruff",
+{%- if cookiecutter.ci_use_spellchecker == "y" %}
+    "codespell[toml]",
+{%- endif %}
+]
 type_check = [
     "django-stubs[compatible-mypy]",
     "djangorestframework-stubs[compatible-mypy]",
@@ -35,3 +40,7 @@ line-length = 100
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]
 "test/**" = ["D", "F403", "F405"]
+
+[tool.codespell]
+skip = '*.min.js'
+ignore-words-list = 'datas'


### PR DESCRIPTION
Right now it is pretty annoying that I only get notified about some silly typo (or false positive) only after submitting PR. 
The configuration was also problematic in a command line...
As for running it under `lint` CI job - it is slightly cheaper to do, since github actions bills by the execution time, but rounds it up to full minutes - so this is in fact improvement in that way as well :)