### PR TITLE
Remove the format step from github ci workflow

### DIFF
--- a/{{cookiecutter.repostory_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.repostory_name}}/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
           cache: "pip"
       - name: Install dependencies
         run: python -m pip install --upgrade nox pip setuptools
-      - name: Run format
-        run: nox -vs format
       - name: Run linters
         run: nox -vs lint
 {%- endif %}


### PR DESCRIPTION
The lint step already checks for formatting errors. By running the format step before lint step, the source is being properly formatted. So the lint step is unable to find the formatting problems (just formatted in the previous step).

I was confused, when locally nox -s lint failed with formatting errors, but github actions didn't!
Fun fact: this repo's workflow file has it correct. But the template workflow file does not.