### PR TITLE
Make the CI show format diff when format check fails

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Migrate cody style to ruff format
+9cf03b2e9f96de2304709b7150a7608c6ba6adfb

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,3 @@
-# Migrate cody style to ruff format
+# Migrate code style to ruff format
 9cf03b2e9f96de2304709b7150a7608c6ba6adfb
+bf05db212bea174f5cf3d7f05f1151baae7f6cd0

--- a/noxfile.py
+++ b/noxfile.py
@@ -112,6 +112,7 @@ def format_(session):
     session.run('ruff', 'check', '--fix', '.')
     run_shellcheck(session, mode="fmt")
     run_readable(session, mode="fmt")
+    session.run('ruff', 'format', '.')
 
 
 @nox.session(python=PYTHON_DEFAULT_VERSION)
@@ -122,6 +123,7 @@ def lint(session):
     session.run('codespell', '.')
     run_shellcheck(session, mode="check")
     run_readable(session, mode="check")
+    session.run('ruff', 'format', '--diff', '.')
 
 
 @contextlib.contextmanager

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,7 @@
 """
 nox configuration for cookiecutter project template.
 """
+
 from __future__ import annotations
 
 import contextlib
@@ -12,22 +13,22 @@ from pathlib import Path
 
 import nox
 
-CI = os.environ.get('CI') is not None
+CI = os.environ.get("CI") is not None
 
-ROOT = Path('.')
-PYTHON_VERSIONS = ['3.11']
+ROOT = Path(".")
+PYTHON_VERSIONS = ["3.11"]
 PYTHON_DEFAULT_VERSION = PYTHON_VERSIONS[-1]
 
-nox.options.default_venv_backend = 'venv'
+nox.options.default_venv_backend = "venv"
 nox.options.reuse_existing_virtualenvs = True
 
 
 # In CI, use Python interpreter provided by GitHub Actions
 if CI:
-    nox.options.force_venv_backend = 'none'
+    nox.options.force_venv_backend = "none"
 
 
-MD_PATHS = ['*.md']
+MD_PATHS = ["*.md"]
 
 
 @functools.lru_cache
@@ -53,14 +54,18 @@ def list_files(suffix: str | None = None) -> list[Path]:
 
 def run_readable(session, mode="check"):
     session.run(
-        'docker',
-        'run',
-        '--platform', 'linux/amd64',
-        '--rm',
-        '-v', f'{ROOT.absolute()}:/data',
-        '-w', '/data',
-        'ghcr.io/bobheadxi/readable:v0.5.0@sha256:423c133e7e9ca0ac20b0ab298bd5dbfa3df09b515b34cbfbbe8944310cc8d9c9',
-        mode, *MD_PATHS,
+        "docker",
+        "run",
+        "--platform",
+        "linux/amd64",
+        "--rm",
+        "-v",
+        f"{ROOT.absolute()}:/data",
+        "-w",
+        "/data",
+        "ghcr.io/bobheadxi/readable:v0.5.0@sha256:423c133e7e9ca0ac20b0ab298bd5dbfa3df09b515b34cbfbbe8944310cc8d9c9",
+        mode,
+        *MD_PATHS,
         external=True,
     )
 
@@ -105,25 +110,25 @@ def run_shellcheck(session, mode="check"):
     session.run(*shellcheck_cmd, external=True)
 
 
-@nox.session(name='format', python=PYTHON_DEFAULT_VERSION)
+@nox.session(name="format", python=PYTHON_DEFAULT_VERSION)
 def format_(session):
     """Lint the code and apply fixes in-place whenever possible."""
-    session.run('pip', 'install', '-e', '.[format]')
-    session.run('ruff', 'check', '--fix', '.')
+    session.run("pip", "install", "-e", ".[format]")
+    session.run("ruff", "check", "--fix", ".")
     run_shellcheck(session, mode="fmt")
     run_readable(session, mode="fmt")
-    session.run('ruff', 'format', '.')
+    session.run("ruff", "format", ".")
 
 
 @nox.session(python=PYTHON_DEFAULT_VERSION)
 def lint(session):
     """Run linters in readonly mode."""
-    session.run('pip', 'install', '-e', '.[lint]')
-    session.run('ruff', 'check', '--diff', '.')
-    session.run('codespell', '.')
+    session.run("pip", "install", "-e", ".[lint]")
+    session.run("ruff", "check", "--diff", ".")
+    session.run("codespell", ".")
     run_shellcheck(session, mode="check")
     run_readable(session, mode="check")
-    session.run('ruff', 'format', '--diff', '.')
+    session.run("ruff", "format", "--diff", ".")
 
 
 @contextlib.contextmanager
@@ -131,14 +136,14 @@ def crufted_project(session):
     session.run("pip", "install", "-e", ".")
     tmpdir = crufted_project.tmpdir
     if not tmpdir:
-        session.notify('cleanup_crufted_project')
+        session.notify("cleanup_crufted_project")
         crufted_project.tmpdir = tmpdir = tempfile.TemporaryDirectory(prefix="rt-crufted_")
         session.log("Creating project in %s", tmpdir.name)
         session.run("cruft", "create", ".", "--output-dir", tmpdir.name, "--no-input")
         project_path = Path(tmpdir.name) / "project"
         with session.chdir(project_path):
             session.run("git", "init", external=True)
-            session.run('./setup-dev.sh', external=True)
+            session.run("./setup-dev.sh", external=True)
     else:
         project_path = Path(tmpdir.name) / "project"
     with session.chdir(project_path):
@@ -163,14 +168,14 @@ def docker_up(session):
 @nox.session(python=PYTHON_DEFAULT_VERSION, tags=["crufted_project"])
 def lint_crufted_project(session):
     with crufted_project(session):
-        session.run('nox', '-s', 'lint')  # TODO: RT-49 re-enable 'type_check'
+        session.run("nox", "-s", "lint")  # TODO: RT-49 re-enable 'type_check'
 
 
 @nox.session(python=PYTHON_DEFAULT_VERSION, tags=["crufted_project"])
 def test_crufted_project(session):
     with crufted_project(session):
         with docker_up(session):
-            session.run('nox', '-s', 'test')
+            session.run("nox", "-s", "test")
 
 
 @nox.session(python=PYTHON_DEFAULT_VERSION)
@@ -180,4 +185,3 @@ def cleanup_crufted_project(session):
         rm_root_owned(session, crufted_project.tmpdir.name)
         crufted_project.tmpdir.cleanup()
         crufted_project.tmpdir = None
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ format = ["ruff"]
 lint = ["ruff", "codespell[toml]"]
 
 [tool.ruff]
-line-length = 100
+line-length = 120
 exclude = [
     "\\{\\{cookiecutter.repostory_name\\}\\}",
 ]

--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/tests/test_setup.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/tests/test_setup.py
@@ -2,6 +2,7 @@
 This test file is here always to indicate that everything was installed and the CI was able to run tests.
 It should always pass as long as all dependencies are properly installed.
 """
+
 from datetime import timedelta
 
 import pytest

--- a/{{cookiecutter.repostory_name}}/noxfile.py
+++ b/{{cookiecutter.repostory_name}}/noxfile.py
@@ -126,7 +126,7 @@ def lint(session):
     session.run("codespell", ".")
     run_shellcheck(session, mode="check")
     run_readable(session, mode="check")
-    session.run("ruff", "format", "--check", ".")
+    session.run("ruff", "format", "--diff", ".")
 
 
 @nox.session(python=PYTHON_DEFAULT_VERSION)


### PR DESCRIPTION
`--diff` does the same as `--check`, except it also shows the relevant diff.