### PR TITLE
Add test to check whether celery beat shedule points to existing tasks

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/tests/test_settings.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/tests/test_settings.py
@@ -1,0 +1,21 @@
+from importlib import import_module
+
+import pytest
+
+
+def test__settings__celery_beat_schedule(settings):
+    """ Ensure that CELERY_BEAT_SCHEDULE points to existing tasks """
+
+    if not hasattr(settings, "CELERY_BEAT_SCHEDULE"):
+        pytest.skip("CELERY_BEAT_SCHEDULE is not defined")
+
+    paths = {task["task"] for task in settings.CELERY_BEAT_SCHEDULE.values()}
+    for path in paths:
+        module_path, task_name = path.rsplit(".", maxsplit=1)
+        try:
+            module = import_module(module_path)
+        except ImportError:
+            pytest.fail(f"The module '{module_path}' does not exist")
+
+        if not hasattr(module, task_name):
+            pytest.fail(f"The task '{task_name}' does not exist in {module_path}")

--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/tests/test_settings.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/tests/test_settings.py
@@ -4,7 +4,7 @@ import pytest
 
 
 def test__settings__celery_beat_schedule(settings):
-    """ Ensure that CELERY_BEAT_SCHEDULE points to existing tasks """
+    """Ensure that CELERY_BEAT_SCHEDULE points to existing tasks"""
 
     if not hasattr(settings, "CELERY_BEAT_SCHEDULE"):
         pytest.skip("CELERY_BEAT_SCHEDULE is not defined")


### PR DESCRIPTION
I renamed a task but I forgot to change task path in `CELERY_BEAT_SCHEDULE` which led to silent non-execution of the task. This test checks that all tasks referenced in `CELERY_BEAT_SCHEDULE` really exist.