### PR TITLE
Silence invalid Host header warnings

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
@@ -302,7 +302,7 @@ if SENTRY_DSN := env("SENTRY_DSN", default=""):
     import sentry_sdk
     from sentry_sdk.integrations.celery import CeleryIntegration
     from sentry_sdk.integrations.django import DjangoIntegration
-    from sentry_sdk.integrations.logging import LoggingIntegration
+    from sentry_sdk.integrations.logging import LoggingIntegration, ignore_logger
     from sentry_sdk.integrations.redis import RedisIntegration
 
     sentry_sdk.init(  # type: ignore
@@ -318,3 +318,4 @@ if SENTRY_DSN := env("SENTRY_DSN", default=""):
             ),
         ],
     )
+    ignore_logger("django.security.DisallowedHost")


### PR DESCRIPTION
[NICE-155](https://reeftechnologies.atlassian.net/browse/NICE-155) [RT-143](https://reeftechnologies.atlassian.net/browse/RT-143)

Silence `django.security.DisallowedHost` logger in sentry
