### PR TITLE
Healthcheck endpoint

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/urls.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/urls.py
@@ -6,6 +6,7 @@ from fingerprint.views import FingerprintView
 {% endif -%}
 {% if cookiecutter.monitoring == "y" %}
 from .{{cookiecutter.django_default_app_name}}.business_metrics import metrics_manager
+from .{{cookiecutter.django_default_app_name}}.healthcheck import healthcheck_view
 from .{{cookiecutter.django_default_app_name}}.metrics import metrics_view
 {%- endif %}
 
@@ -18,6 +19,7 @@ urlpatterns = [
     {%- if cookiecutter.monitoring == "y" %}
     path("metrics", metrics_view, name="prometheus-django-metrics"),
     path("business-metrics", metrics_manager.view, name="prometheus-business-metrics"),
+    path("healthcheck", healthcheck_view, name="healthcheck"),
     {%- endif %}
 ]
 

--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/healthcheck.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/healthcheck.py
@@ -1,0 +1,61 @@
+{%- if cookiecutter.monitoring == "y" -%}
+import os
+from datetime import UTC, datetime
+from http import HTTPStatus
+from typing import Any
+
+from django.http import HttpRequest, HttpResponse, JsonResponse
+from redis import Redis
+
+from .models import HealthcheckModel
+
+
+def check_database(status: dict[str, Any]) -> bool:
+    try:
+        # delete all existing healthcheck records to prevent table bloat
+        HealthcheckModel.objects.all().delete()
+
+        # create and save a new healthcheck record
+        obj = HealthcheckModel.objects.create(
+            check_date=datetime.now(tz=UTC),
+        )
+        obj.save()
+
+        status["database_ok"] = True
+        return True
+    except Exception as e:
+        status["database_ok"] = False
+        status["database_error"] = repr(e)
+        return False
+
+
+def check_redis(status: dict[str, Any]) -> bool:
+    try:
+        redis_host = os.environ["REDIS_HOST"]
+        redis_port = int(os.environ["REDIS_PORT"])
+        redis = Redis(redis_host, redis_port, socket_connect_timeout=1)
+
+        # echo test
+        echo_test = str(datetime.now(tz=UTC)).encode("utf8")
+        assert redis.echo(echo_test) == echo_test
+
+        status["redis_ok"] = True
+        return True
+    except Exception as e:
+        status["redis_ok"] = False
+        status["redis_error"] = repr(e)
+        return False
+
+
+def healthcheck_view(_request: HttpRequest) -> HttpResponse:
+    status = {}
+
+    all_ok = True
+    all_ok &= check_database(status)
+    all_ok &= check_redis(status)
+    status["all_ok"] = all_ok
+
+    response = JsonResponse(status)
+    response.status_code = HTTPStatus.OK if all_ok else HTTPStatus.INTERNAL_SERVER_ERROR
+    return response
+{% endif -%}

--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/models.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/models.py
@@ -1,1 +1,10 @@
+{%- if cookiecutter.monitoring == "y" -%}
 from django.db import models  # noqa
+
+
+class HealthcheckModel(models.Model):
+    check_date = models.DateTimeField()
+
+    class Meta:
+        db_table = "healthcheck_model"
+{% endif -%}


### PR DESCRIPTION
Added `/healthcheck` endpoint.

It's enabled if `cookiecutter.monitoring` is set. Should I always enable it, or create a new `cookiecutter.healthcheck` env?

Checks database and redis. Returns 200 or 500 status code with status json:

```jsonc
// HTTP 200
{
  "database_ok": true,
  "redis_ok": true,
  "all_ok": true
}
```
```jsonc
// HTTP 500
{
  "database_ok": true,
  "redis_ok": false,
  "redis_error": "ConnectionError('Error 111 connecting to localhost:8379. Connection refused.')",
  "all_ok": false
}
```
```jsonc
// HTTP 500
{
  "database_ok": false,
  "database_error": "ProgrammingError('relation \"healthcheck_model\" does not exist\\nLINE 1: DELETE FROM \"healthcheck_model\"\\n                    ^\\n')",
  "redis_ok": true,
  "all_ok": false
}

```