### PR TITLE
Don't codespell monitoring certs

### DIFF
--- a/{{cookiecutter.repostory_name}}/pyproject.toml
+++ b/{{cookiecutter.repostory_name}}/pyproject.toml
@@ -90,5 +90,5 @@ ignore = [
 "test/**" = ["D", "F403", "F405"]
 
 [tool.codespell]
-skip = '*.min.js,pdm.lock'
+skip = '*.min.js,pdm.lock,*/monitoring_certs/*'
 ignore-words-list = 'datas'


### PR DESCRIPTION
Otherwise
```
nox > codespell .
./devops/tf/main/files/nginx/monitoring_certs/monitoring-ca.crt.txt:18: TE ==> THE, BE, WE, TO
nox > Command codespell . failed with exit code 65
nox > Session lint failed.
Error: Process completed with exit code 1.
```