### PR TITLE
Don't set shell flags in shebang line

### DIFF
--- a/{{cookiecutter.repostory_name}}/bin/backup-db-to-email.sh
+++ b/{{cookiecutter.repostory_name}}/bin/backup-db-to-email.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/bin/bash
+set -eu
 
 if [ "$(basename "$0")" == 'bin' ]; then
   cd ..

--- a/{{cookiecutter.repostory_name}}/bin/backup-db.sh
+++ b/{{cookiecutter.repostory_name}}/bin/backup-db.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/{{cookiecutter.repostory_name}}/bin/backup-file-to-b2.sh
+++ b/{{cookiecutter.repostory_name}}/bin/backup-file-to-b2.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/{{cookiecutter.repostory_name}}/bin/common.sh
+++ b/{{cookiecutter.repostory_name}}/bin/common.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 
 if [ -z "${_COMMON_SH_LOADED:-}" ]; then
   PATH=/usr/local/sbin:/usr/local/bin:$PATH

--- a/{{cookiecutter.repostory_name}}/bin/list-b2-backups.sh
+++ b/{{cookiecutter.repostory_name}}/bin/list-b2-backups.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/{{cookiecutter.repostory_name}}/bin/prepare-os.sh
+++ b/{{cookiecutter.repostory_name}}/bin/prepare-os.sh
@@ -1,5 +1,6 @@
-#!/bin/sh -eux
+#!/bin/sh
 # Copyright 2020, Reef Technologies (reef.pl), All rights reserved.
+set -eux
 
 DOCKER_BIN="$(command -v docker || true)"
 DOCKER_COMPOSE_INSTALLED="$(docker compose version || true)"

--- a/{{cookiecutter.repostory_name}}/bin/restore-db-from-b2.sh
+++ b/{{cookiecutter.repostory_name}}/bin/restore-db-from-b2.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/{{cookiecutter.repostory_name}}/bin/restore-db.sh
+++ b/{{cookiecutter.repostory_name}}/bin/restore-db.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/bin/bash
+set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source "${SCRIPT_DIR}/common.sh"
 

--- a/{{cookiecutter.repostory_name}}/deploy-to-aws.sh
+++ b/{{cookiecutter.repostory_name}}/deploy-to-aws.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash
+set -e
 # shellcheck disable=2086
 ./devops/scripts/build-backend.sh $1
 ./devops/scripts/deploy-backend.sh $1

--- a/{{cookiecutter.repostory_name}}/deploy-to-aws.sh
+++ b/{{cookiecutter.repostory_name}}/deploy-to-aws.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 # shellcheck disable=2086
-./devops/scripts/build-backend.sh $1
-./devops/scripts/deploy-backend.sh $1
+./devops/scripts/build-backend.sh "$1"
+./devops/scripts/deploy-backend.sh "$1"

--- a/{{cookiecutter.repostory_name}}/deploy.sh
+++ b/{{cookiecutter.repostory_name}}/deploy.sh
@@ -1,5 +1,6 @@
-#!/bin/sh -eux
+#!/bin/sh
 # Copyright 2024, Reef Technologies (reef.pl), All rights reserved.
+set -eux
 
 if [ ! -f ".env" ]; then
     echo "\e[31mPlease setup the environment first!\e[0m";

--- a/{{cookiecutter.repostory_name}}/devops/scripts/build-backend.sh
+++ b/{{cookiecutter.repostory_name}}/devops/scripts/build-backend.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -xe
+#!/bin/bash
+set -xe
 
 THIS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source "$THIS_DIR"/vars.sh

--- a/{{cookiecutter.repostory_name}}/devops/scripts/deploy-backend.sh
+++ b/{{cookiecutter.repostory_name}}/devops/scripts/deploy-backend.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -xe
+#!/bin/bash
+set -xe
 
 THIS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source "$THIS_DIR"/vars.sh

--- a/{{cookiecutter.repostory_name}}/letsencrypt_setup.sh
+++ b/{{cookiecutter.repostory_name}}/letsencrypt_setup.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eux
-
+#!/bin/bash
+set -eux
 RELPATH="$(dirname "$0")"
 ABSPATH="$(realpath "$RELPATH")"
 


### PR DESCRIPTION
Enam
> As we were discussing on the status call: setting shell options in the shebang is not the same as setting them with set.
Setting options in the shebang of a script only sets them if called as a script (i.e. ./script.sh). It does not set the options when called with sh script.sh or bash script.sh. To replicate the shebang options, you have to call the shell with the same options (i.e. sh -x script.sh).