### PR TITLE
Remove pdm workaround

### DIFF
--- a/{{cookiecutter.repostory_name}}/setup-dev.sh
+++ b/{{cookiecutter.repostory_name}}/setup-dev.sh
@@ -8,12 +8,6 @@ ENV_DIR="./envs/dev"
 # shellcheck disable=SC2164
 cd "${PROJECT_DIR}"
 
-# Workaround for PDM which sometimes creates a 3.10 venv
-# https://github.com/pdm-project/pdm/issues/2789
-if [[ ! -d ".venv" ]]; then
-    python3.11 -m venv .venv
-fi
-
 # Create a lock file if doesn't exist
 if [[ ! -f "pdm.lock" ]]; then
     pdm lock --group :all


### PR DESCRIPTION
Remove PDM workaround, problem is caused by incompatibility between `pdm` and the handbook recommended `virtualenvwrapper` setup in `.bashrc`, but we are removing that - https://github.com/reef-technologies/handbook/pull/122