### PR TITLE
Refresh migration metrics every metrics export

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/metrics.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/metrics.py
@@ -5,6 +5,7 @@ import os
 import prometheus_client
 from django.http import HttpResponse
 from django_prometheus.exports import ExportToDjangoView
+from django_prometheus.migrations import ExportMigrations
 from prometheus_client import multiprocess
 
 
@@ -21,6 +22,8 @@ ENV_VAR_NAME = "PROMETHEUS_MULTIPROC_DIR"
 
 def metrics_view(request):
     """Exports metrics as a Django view"""
+    # Export Django migration metrics
+    ExportMigrations()
     if os.environ.get(ENV_VAR_NAME):
         registry = prometheus_client.CollectorRegistry()
         RecursiveMultiProcessCollector(registry)


### PR DESCRIPTION
Closes #186 

Every metrics call will get the latest migration-related metrics.