### PR TITLE
Fix SSO email trust

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
@@ -454,7 +454,7 @@ if SENTRY_DSN := env("SENTRY_DSN", default=""):
         ],
     )
     ignore_logger("django.security.DisallowedHost")
-{% if cookiecutter.use_allauth == "y" -%}
+{% if cookiecutter.use_allauth == "y" %}
 LOGIN_URL = reverse_lazy("account_login")
 LOGIN_REDIRECT_URL = "/"
 ACCOUNT_AUTHENTICATION_METHOD = "email"


### PR DESCRIPTION
It looks that the SOCIALACCOUNT_EMAIL_AUTHENTICATION doesn't work as described in allauth's documentation. It's a global setting so it should kick in when there is no provider-specific flag, yet it seems it still tries to grab the value from the provider config, gets an empty result and is satisfied because it looks falsy.

This PR changes the template so that the auth trust flag (EMAIL_AUTHENTICATION) is written into provider configs instead.

Also I introduced a loop to generate the config as 7 out of 10 providers are exactly the same. Ones that require additional config fields have been pulled up the config.

Cookiecutter variables are not changed in this PR - they stay exactly as they were.