### PR TITLE
Expose celery metrics

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/celery.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/celery.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django_structlog.celery.steps import DjangoStructLogInitStep
 from more_itertools import chunked
 {%- if cookiecutter.monitoring == "y" %}
-from prometheus_client import multiprocess
+from prometheus_client import Gauge, multiprocess
 {% endif %}
 from .settings import configure_structlog
 
@@ -20,6 +20,14 @@ app = Celery("{{cookiecutter.django_project_name}}")
 app.config_from_object("django.conf:settings", namespace="CELERY")
 app.steps["worker"].add(DjangoStructLogInitStep)
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+
+{%- if cookiecutter.monitoring == "y" %}
+num_tasks_in_queue = Gauge(
+    "celery_queue_len",
+    "How many tasks are there in a queue",
+    labelnames=("queue",),
+)
+{% endif %}
 
 
 @setup_logging.connect

--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/celery.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/celery.py
@@ -27,7 +27,7 @@ num_tasks_in_queue = Gauge(
     "How many tasks are there in a queue",
     labelnames=("queue",),
 )
-{% endif %}
+{%- endif %}
 
 
 @setup_logging.connect

--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
@@ -347,6 +347,8 @@ CELERY_TASK_ANNOTATIONS = {"*": {"acks_late": True, "reject_on_worker_lost": Tru
 CELERY_TASK_ROUTES = {"*": {"queue": "celery"}}
 CELERY_TASK_TIME_LIMIT = int(timedelta(minutes=5).total_seconds())
 CELERY_TASK_ALWAYS_EAGER = env.bool("CELERY_TASK_ALWAYS_EAGER", default=False)
+CELERY_WORKER_SEND_TASK_EVENTS = True
+CELERY_TASK_SEND_SENT_EVENT = True
 CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"

--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/metrics.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/metrics.py
@@ -19,7 +19,7 @@ class RecursiveMultiProcessCollector(multiprocess.MultiProcessCollector):
         return self.merge(files, accumulate=True)
 
 
-if (is_multiprocess := bool(os.environ.get("PROMETHEUS_MULTIPROC_DIR"))):
+if is_multiprocess := bool(os.environ.get("PROMETHEUS_MULTIPROC_DIR")):
     registry = prometheus_client.CollectorRegistry()
     RecursiveMultiProcessCollector(registry)
 else:

--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/metrics.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/metrics.py
@@ -7,11 +7,9 @@ import prometheus_client
 from django.conf import settings
 from django.http import HttpResponse
 from django_prometheus.exports import ExportToDjangoView
-from prometheus_client import multiprocess
-from prometheus_client.core import REGISTRY, GaugeMetricFamily, Metric
-from prometheus_client.registry import Collector
+from prometheus_client import REGISTRY, multiprocess
 
-from ..celery import get_num_tasks_in_queue
+from ..celery import num_tasks_in_queue, get_num_tasks_in_queue
 
 
 class RecursiveMultiProcessCollector(multiprocess.MultiProcessCollector):
@@ -22,34 +20,24 @@ class RecursiveMultiProcessCollector(multiprocess.MultiProcessCollector):
         return self.merge(files, accumulate=True)
 
 
-ENV_VAR_NAME = "PROMETHEUS_MULTIPROC_DIR"
+if (is_multiprocess := bool(os.environ.get("PROMETHEUS_MULTIPROC_DIR"))):
+    registry = prometheus_client.CollectorRegistry()
+    RecursiveMultiProcessCollector(registry)
+else:
+    registry = REGISTRY
 
 
 def metrics_view(request):
     """Exports metrics as a Django view"""
-    if os.environ.get(ENV_VAR_NAME):
-        registry = prometheus_client.CollectorRegistry()
-        RecursiveMultiProcessCollector(registry)
-        registry.register(CustomCeleryCollector())
+
+    for queue in settings.CELERY_TASK_QUEUES:
+        num_tasks_in_queue.labels(queue.name).set(get_num_tasks_in_queue(queue.name))
+
+    if is_multiprocess:
         return HttpResponse(
             prometheus_client.generate_latest(registry),
             content_type=prometheus_client.CONTENT_TYPE_LATEST,
         )
-    else:
-        return ExportToDjangoView(request)
 
-
-class CustomCeleryCollector(Collector):
-    def collect(self) -> Iterator[Metric]:
-        num_tasks_in_queue = GaugeMetricFamily(
-            "celery_queue_len",
-            "How many tasks are there in a queue",
-            labels=("queue",),
-        )
-        for queue in settings.CELERY_TASK_QUEUES:
-            num_tasks_in_queue.add_metric([queue.name], get_num_tasks_in_queue(queue.name))
-        yield num_tasks_in_queue
-
-
-REGISTRY.register(CustomCeleryCollector())
+    return ExportToDjangoView(request)
 {% endif %}

--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/metrics.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/metrics.py
@@ -1,7 +1,6 @@
 {%- if cookiecutter.monitoring == "y" -%}
 import glob
 import os
-from collections.abc import Iterator
 
 import prometheus_client
 from django.conf import settings
@@ -9,7 +8,7 @@ from django.http import HttpResponse
 from django_prometheus.exports import ExportToDjangoView
 from prometheus_client import REGISTRY, multiprocess
 
-from ..celery import num_tasks_in_queue, get_num_tasks_in_queue
+from ..celery import get_num_tasks_in_queue, num_tasks_in_queue
 
 
 class RecursiveMultiProcessCollector(multiprocess.MultiProcessCollector):

--- a/{{cookiecutter.repostory_name}}/devops/tf/main/files/nginx/templates/default.conf.template
+++ b/{{cookiecutter.repostory_name}}/devops/tf/main/files/nginx/templates/default.conf.template
@@ -114,6 +114,7 @@ server {
         proxy_pass http://gunicorn/business-metrics;
     }
 
+    {% if cookiecutter.use_flower == "y" -%}
     location /celery-metrics/ {
         proxy_pass_header Server;
         proxy_redirect off;
@@ -122,6 +123,7 @@ server {
         proxy_set_header X_SCHEME $scheme;
         proxy_pass http://celery-flower:5555/metrics;
     }
+    {% endif %}
 }
 {%- endif %}
 

--- a/{{cookiecutter.repostory_name}}/devops/tf/main/files/nginx/templates/default.conf.template
+++ b/{{cookiecutter.repostory_name}}/devops/tf/main/files/nginx/templates/default.conf.template
@@ -114,6 +114,14 @@ server {
         proxy_pass http://gunicorn/business-metrics;
     }
 
+    location /celery-metrics/ {
+        proxy_pass_header Server;
+        proxy_redirect off;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X_SCHEME $scheme;
+        proxy_pass http://celery-flower:5555/metrics;
+    }
 }
 {%- endif %}
 

--- a/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
+++ b/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
@@ -110,11 +110,12 @@ services:
     env_file: ./.env
     environment:
       - DEBUG=off
+      - FLOWER_TASK_RUNTIME_METRIC_BUCKETS=1,2,3,5,10,20,30,45,60,120,180,240,300,600,inf
     command: celery --app={{cookiecutter.django_project_name}} --broker="${CELERY_BROKER_URL}" flower --basic_auth="${CELERY_FLOWER_USER}:${CELERY_FLOWER_PASSWORD}"
     depends_on:
       - celery-worker
     ports:
-      - 5555:5555
+      - 127.0.0.1:5555:5555
     logging:
       <<: *logging
   {% endif %}

--- a/{{cookiecutter.repostory_name}}/nginx/templates/default.conf.template
+++ b/{{cookiecutter.repostory_name}}/nginx/templates/default.conf.template
@@ -178,14 +178,14 @@ server {
     }
 
     {% if cookiecutter.use_flower == "y" -%}
-        location /celery-metrics/ {
-            proxy_pass_header Server;
-            proxy_redirect off;
-            proxy_set_header Host $http_host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X_SCHEME $scheme;
-            proxy_pass http://celery-flower:5555/metrics;
-        }
+    location /celery-metrics/ {
+        proxy_pass_header Server;
+        proxy_redirect off;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X_SCHEME $scheme;
+        proxy_pass http://celery-flower:5555/metrics;
+    }
     {% endif %}
 }
 {%- endif %}


### PR DESCRIPTION
I tried both 
1) standalone dockerized celery exporter - https://github.com/danihodovic/celery-exporter
2) celery-flower

The former has more metrics but requires separate image and does not have a label by task (as far as i remember), so i switched back to flower. 

However, i also needed a queue length metric, so I added it manually into our django app (`CustomCeleryCollector`).

Grafana is already configured to show the metrics.
![Screenshot_2024-10-29_14-15-39](https://github.com/user-attachments/assets/789209bc-7499-4c57-b890-daeaddeda99c)
