### PR TITLE
Replace /application-business-metrics/ with /business-metrics/

### DIFF
--- a/{{cookiecutter.repostory_name}}/devops/tf/main/files/nginx/templates/default.conf.template
+++ b/{{cookiecutter.repostory_name}}/devops/tf/main/files/nginx/templates/default.conf.template
@@ -101,7 +101,7 @@ server {
         proxy_pass http://app:8000/metrics;
     }
 
-    location /application-business-metrics/ {
+    location /business-metrics/ {
         proxy_pass_header Server;
         proxy_redirect off;
         proxy_set_header Host $http_host;


### PR DESCRIPTION
Looks like a typo, since prometheus monitoring is configured to scrape `/business-metrics`, not `/application-business-metrics`. Also, the other nginx config (not from `devops/` folder) has just `/bisiness-metrics`.