### PR TITLE
RT-258 Update vulnrelay to write metrics to node-exporter

### DIFF
--- a/{{cookiecutter.repostory_name}}/devops/tf/main/files/docker-compose.yml
+++ b/{{cookiecutter.repostory_name}}/devops/tf/main/files/docker-compose.yml
@@ -41,9 +41,13 @@ services:
     pid: host
     volumes:
       - /:/host:ro,rslave
+      - nodeexporter_collectors:/textfile_collectors
     command:
       - '--path.rootfs=/host'
       - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+      {% if cookiecutter.vulnerabilities_scanning == 'y' %}
+      - '--collector.textfile.directory=textfile_collectors'
+      {% endif %}
     logging: &exporter_logging
       driver: journald
       options:
@@ -107,8 +111,11 @@ services:
     container_name: vulnrelay
     restart: unless-stopped
     env_file: ./.vuln.env
+    environment:
+      - METRICS_DIR=/app/metrics
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      - nodeexporter_collectors:/app/metrics
     logging:
       driver: awslogs
       options:
@@ -134,3 +141,4 @@ services:
 volumes:
   backend-static:
   gunicorn-socket:
+  nodeexporter_collectors:

--- a/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
+++ b/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
@@ -171,9 +171,14 @@ services:
     pid: host
     volumes:
       - /:/host:ro,rslave
+      - nodeexporter_collectors:/textfile_collectors
+      
     command:
       - '--path.rootfs=/host'
       - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc|run|boot|var/.+)($$|/)'
+      {% if cookiecutter.vulnerabilities_scanning == 'y' %}
+      - '--collector.textfile.directory=textfile_collectors'
+      {% endif %}
       {% if cookiecutter.monitor_tcpstat == 'y' %}
       - '--collector.tcpstat'
       {% endif %}
@@ -222,8 +227,11 @@ services:
     container_name: vulnrelay
     restart: unless-stopped
     env_file: ./.vuln.env
+    environment:
+      - METRICS_DIR=/app/metrics
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      - nodeexporter_collectors:/app/metrics
     logging:
       <<: *logging
   watchtower:
@@ -239,3 +247,4 @@ services:
 volumes:
   backend-static:
   gunicorn-socket:
+  nodeexporter_collectors:


### PR DESCRIPTION
**WARNING:** This depends on https://github.com/reef-technologies/vulnrelay/pull/5 to be approved first.

We modified the compose.yml files to link the vulnrelay metrics directory to a text file collector on node-exporter.