### PR TITLE
Switch CI workflow from pdm to uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.11"
+          version: "0.5.x"
       - name: Install dependencies
         run: python -m pip install --upgrade nox
       - name: Run linters
@@ -39,9 +39,9 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_DEFAULT_VERSION }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.11"
+          version: "0.5.x"
       - name: Install dependencies
         run: python -m pip install --upgrade nox
       - name: Run checks on project created from template

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 .nox
 __pycache__
 *.egg-info/
-.pdm-python

--- a/{{cookiecutter.repostory_name}}/.dockerignore
+++ b/{{cookiecutter.repostory_name}}/.dockerignore
@@ -13,7 +13,6 @@
 venv
 .backups/
 .envrc
-.pdm-python
 .terraform.lock.hcl
 .terraform/
 .nox/

--- a/{{cookiecutter.repostory_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.repostory_name}}/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
         with:
           python-version: {% raw %}${{ env.PYTHON_DEFAULT_VERSION }}{% endraw %}
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.11"
+          version: "0.5.x"
       - name: Install nox
         run: python -m pip install --upgrade nox
       - name: Run linters
@@ -43,9 +43,9 @@ jobs:
         with:
           python-version: {% raw %}${{ env.PYTHON_DEFAULT_VERSION }}{% endraw %}
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.11"
+          version: "0.5.x"
       - name: Prepare environment
         run: ./setup-dev.sh
       - name: Run dockerized services

--- a/{{cookiecutter.repostory_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.repostory_name}}/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   PYTHON_DEFAULT_VERSION: "3.11"
+  ENV_FILL_MISSING_VALUES: 1
 
 jobs:
 {%- if cookiecutter.ci_use_linter == "y" %}
@@ -21,9 +22,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: {% raw %}${{ env.PYTHON_DEFAULT_VERSION }}{% endraw %}
-          cache: "pip"
-      - name: Install dependencies
-        run: python -m pip install --upgrade nox 'pdm>=2.12,<3'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.5.11"
+      - name: Install nox
+        run: python -m pip install --upgrade nox
       - name: Run linters
         run: nox -vs lint
 {%- endif %}
@@ -38,15 +42,18 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: {% raw %}${{ env.PYTHON_DEFAULT_VERSION }}{% endraw %}
-          cache: "pip"
-      - name: Install dependencies
-        run: python -m pip install --upgrade nox 'pdm>=2.12,<3'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.5.11"
       - name: Prepare environment
         run: ./setup-dev.sh
       - name: Run dockerized services
         run: docker compose up -d --wait
       - name: Run migrations
-        run: cd app/src && pdm run python manage.py wait_for_database --timeout 120 && pdm run python manage.py migrate
+        run: cd app/src && uv run python manage.py wait_for_database --timeout 120 && uv run python manage.py migrate
+      - name: Install nox
+        run: python -m pip install --upgrade nox
       - name: Run unit tests
         run: nox -vs test
       - name: Stop dockerized services

--- a/{{cookiecutter.repostory_name}}/.gitignore
+++ b/{{cookiecutter.repostory_name}}/.gitignore
@@ -14,7 +14,6 @@ venv
 media/
 .backups/
 .envrc
-.pdm-python
 .terraform.lock.hcl
 .terraform/
 .nox/


### PR DESCRIPTION
I recently crufted a new project from latest cookiecutter and got a bunch of errors during CI process. Turns out we switched to uv for dependency management but haven't updated CI scripts, which is addressed by this PR.

I removed every mention of PDM except build backend in `pyproject.toml`, since [uv doesn't have its own build backend yet](https://github.com/astral-sh/uv/issues/8779).

Tested it on brand new crufted repo, all CI steps (lint + test) pass.