### PR TITLE
Fix expose celery metrics

### DIFF
--- a/{{cookiecutter.repostory_name}}/nginx/templates/default.conf.template
+++ b/{{cookiecutter.repostory_name}}/nginx/templates/default.conf.template
@@ -168,7 +168,7 @@ server {
         proxy_pass http://gunicorn/metrics;
     }
 
-    location /business-metrics {
+    location /business-metrics/ {
         proxy_pass_header Server;
         proxy_redirect off;
         proxy_set_header Host $http_host;
@@ -176,6 +176,17 @@ server {
         proxy_set_header X_SCHEME $scheme;
         proxy_pass http://gunicorn/business-metrics;
     }
+
+    {% if cookiecutter.use_flower == "y" -%}
+        location /celery-metrics/ {
+            proxy_pass_header Server;
+            proxy_redirect off;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X_SCHEME $scheme;
+            proxy_pass http://celery-flower:5555/metrics;
+        }
+    {% endif %}
 }
 {%- endif %}
 


### PR DESCRIPTION
For some reason cookiecutter has this bug of not exposing celery metrics in poor man's deployment. This PR fixes it.