### PR TITLE
Configure gcr mirrors to avoid possible dockerhub limits

### DIFF
--- a/{{cookiecutter.repostory_name}}/bin/prepare-os.sh
+++ b/{{cookiecutter.repostory_name}}/bin/prepare-os.sh
@@ -53,6 +53,16 @@ if [ ! -x "${DOCKER_BIN}" ] || [ ! -x "${DOCKER_COMPOSE_INSTALLED}" ]; then
     usermod -aG docker "$USER"
 fi
 
+if [ ! -x "${JQ_BIN}" ]; then
+  apt-get -y install jq
+fi
+
+if [ ! -f /etc/docker/daemon.json ]; then
+  echo '{ "registry-mirrors": ["https://mirror.gcr.io"] }' > /etc/docker/daemon.json
+else
+  jq '.["registry-mirrors"] += ["https://mirror.gcr.io"]' /etc/docker/daemon.json > /etc/docker/daemon.tmp && mv /etc/docker/daemon.tmp /etc/docker/daemon.json
+fi
+
 if [ ! -x "${AWS_CLI}" ]; then
   apt-get -y install gpg unzip
   curl "https://awscli.amazonaws.com/awscli-exe-linux-${PLATFORM}.zip" -o "awscliv2.zip"
@@ -91,8 +101,4 @@ EOF
   gpg --verify awscliv2.sig awscliv2.zip
   unzip awscliv2.zip
   ./aws/install
-fi
-
-if [ ! -x "${JQ_BIN}" ]; then
-  apt-get -y install jq
 fi

--- a/{{cookiecutter.repostory_name}}/bin/prepare-os.sh
+++ b/{{cookiecutter.repostory_name}}/bin/prepare-os.sh
@@ -8,6 +8,7 @@ SENTRY_CLI="$(command -v sentry-cli || true)"
 B2_CLI="$(command -v b2 || true)"
 AWS_CLI="$(command -v aws || true)"
 JQ_BIN="$(command -v jq || true)"
+USER="$(id -un 1000)"
 
 if [ -x "${DOCKER_BIN}" ] && [ -n "${DOCKER_COMPOSE_INSTALLED}" ] && [ -x "${SENTRY_CLI}" ] && [ -x "${B2_CLI}" ] && [ -x "${AWS_CLI}" ] && [ -x "${JQ_BIN}" ]; then
     echo "\e[32mEverything required is already installed\e[0m";
@@ -62,6 +63,8 @@ if [ ! -f /etc/docker/daemon.json ]; then
 else
   jq '.["registry-mirrors"] += ["https://mirror.gcr.io"]' /etc/docker/daemon.json > /etc/docker/daemon.tmp && mv /etc/docker/daemon.tmp /etc/docker/daemon.json
 fi
+
+service docker restart
 
 if [ ! -x "${AWS_CLI}" ]; then
   apt-get -y install gpg unzip

--- a/{{cookiecutter.repostory_name}}/devops/packer/docker-optimized.pkr.hcl
+++ b/{{cookiecutter.repostory_name}}/devops/packer/docker-optimized.pkr.hcl
@@ -70,6 +70,13 @@ build {
       "sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin",
       "sudo gpasswd -a ubuntu docker",
       "sudo mkdir -p /etc/docker/",
+
+      "if [ ! -f /etc/docker/daemon.json ]; then
+        echo '{ "registry-mirrors": ["https://mirror.gcr.io"] }' > /etc/docker/daemon.json
+      else
+        jq '.["registry-mirrors"] += ["https://mirror.gcr.io"]' /etc/docker/daemon.json > /etc/docker/daemon.tmp && mv /etc/docker/daemon.tmp /etc/docker/daemon.json
+      fi",
+
       "sudo service docker restart",
     ]
   }

--- a/{{cookiecutter.repostory_name}}/devops/tf/main/files/cloud-init.yml
+++ b/{{cookiecutter.repostory_name}}/devops/tf/main/files/cloud-init.yml
@@ -23,6 +23,13 @@ write_files:
       apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
       gpasswd -a ubuntu docker
       mkdir -p /etc/docker/
+
+      if [ ! -f /etc/docker/daemon.json ]; then
+        echo '{ "registry-mirrors": ["https://mirror.gcr.io"] }' > /etc/docker/daemon.json
+      else
+        jq '.["registry-mirrors"] += ["https://mirror.gcr.io"]' /etc/docker/daemon.json > /etc/docker/daemon.tmp && mv /etc/docker/daemon.tmp /etc/docker/daemon.json
+      fi
+
       service docker restart
 
   - path: /home/ubuntu/cloud-init.sh

--- a/{{cookiecutter.repostory_name}}/envs/dev/docker-compose.yml
+++ b/{{cookiecutter.repostory_name}}/envs/dev/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   redis:
-    image: redis:6-alpine
+    image: mirror.gcr.io/redis:6-alpine
     command: redis-server --appendonly yes
     healthcheck:
       test: redis-cli ping
@@ -12,7 +12,7 @@ services:
       - ${REDIS_PORT}:6379
 
   db:
-    image: postgres:14.0-alpine
+    image: mirror.gcr.io/postgres:14.0-alpine
     healthcheck:
       test: pg_isready -U ${POSTGRES_USER} || exit 1
     environment:


### PR DESCRIPTION
- **Add mirror.gcr.io to cloud-init and packer deployments**
- **Use images from mirror.gcr.io in /dev/docker-compose.yml**
