### PR TITLE
Make sentry ignore celery.receivers logger

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
@@ -495,6 +495,7 @@ if SENTRY_DSN := env("SENTRY_DSN", default=""):
         ],
     )
     ignore_logger("django.security.DisallowedHost")
+    ignore_logger("django_structlog.celery.receivers")
 {% if cookiecutter.use_allauth == "y" %}
 LOGIN_URL = reverse_lazy("account_login")
 LOGIN_REDIRECT_URL = "/"


### PR DESCRIPTION
The `celery.receivers` logger is used by celery for posting updates about task
state transitions. Thus, it will contain error log messages in case of task
failures. However, the exception that lead to the task failure is
already being reported to sentry, and the above mentioned logger leads
to duplicated error notifications in sentry.
to duplicate error messages.
