### PR TITLE
Update Django to 5.2 LTS + other python dependencies

### DIFF
--- a/{{cookiecutter.repostory_name}}/pyproject.toml
+++ b/{{cookiecutter.repostory_name}}/pyproject.toml
@@ -3,48 +3,48 @@ name = "{{cookiecutter.repostory_name}}"
 requires-python = "==3.11.*"
 version = "0"
 dependencies = [
-    "Django~=4.2.4",
+    "Django~=5.2.0",
     {% if cookiecutter.csp_enabled == "y" %}
     "django-csp==3.7",
     {% endif %}
-    "django-constance[database]==3.1.0",
-    "django-cors-headers~=4.2.0",
-    "django-environ~=0.11.2",
-    "django-extensions==3.2.3",
+    "django-constance==4.3.2",
+    "django-cors-headers~=4.7.0",
+    "django-environ~=0.12.0",
+    "django-extensions==4.1",
     "django-probes==1.7.0",
-    "django-debug-toolbar==4.1.0",
-    "django-structlog{% if cookiecutter.use_celery == "y" %}[celery]{% endif %}==8.0.0",
+    "django-debug-toolbar==6.0.0",
+    "django-structlog{% if cookiecutter.use_celery == "y" %}[celery]{% endif %}==9.1.0",
     {% if cookiecutter.use_rest_framework == 'y' %}
     "djangorestframework~=3.16.0",
     "drf-spectacular[sidecar]~=0.28.0",
     {% endif %}
     {% if cookiecutter.use_celery == "y" %}
-    "celery~=5.3.1",
+    "celery~=5.5.2",
     {% if cookiecutter.use_flower == 'y' %}
     "flower~=2.0.0",
     {% endif %}
     {% endif %}
-    "gunicorn==20.1.0",
-    "psycopg[binary]~=3.1.19",
-    "redis~=4.6.0",
-    "sentry-sdk==1.3.0",
-    "ipython~=8.14.0",
-    "nox==2024.10.9",
-    "more-itertools~=10.3.0",
+    "gunicorn==23.0.0",
+    "psycopg[binary]~=3.2.0",
+    "redis~=6.4.0",
+    "sentry-sdk==2.0",
+    "ipython~=9.5.0",
+    "nox==2025.5.1",
+    "more-itertools~=10.7.0",
     {% if cookiecutter.monitoring == "y" %}
     "psutil>=5.9.8",
-    "prometheus-client~=0.17.0",
-    "django-prometheus==2.3.1",
+    "prometheus-client~=0.22.1",
+    "django-prometheus==2.4.1",
     "django-business-metrics>=1.0.1,<2",
     {% endif %}
     {% if cookiecutter.use_fingerprinting == "y" %}
     "django-fingerprint-rt~=0.1.0",
     {% endif %}
     {% if cookiecutter.use_channels == "y" %}
-    "channels[daphne]~=4.0",
-    "channels-redis~=4.2.0",
-    "uvicorn[standard]==0.29",
-    "pydantic~=2.0",
+    "channels[daphne]~=4.3.0",
+    "channels-redis~=4.3.0",
+    "uvicorn[standard]==0.35.0",
+    "pydantic~=2.11.7",
     {% endif %}
     {% if cookiecutter.use_allauth == "y" %}
     "django-allauth[socialaccount]~=0.63.1",

--- a/{{cookiecutter.repostory_name}}/setup-dev.sh
+++ b/{{cookiecutter.repostory_name}}/setup-dev.sh
@@ -8,10 +8,6 @@ ENV_DIR="./envs/dev"
 # shellcheck disable=SC2164
 cd "${PROJECT_DIR}"
 
-if [[ ! -d ".venv" ]]; then
-    python3.11 -m venv .venv
-fi
-
 # Create a lock file if doesn't exist
 if [[ ! -f "uv.lock" ]]; then
     uv lock


### PR DESCRIPTION
Update python dependencies. Changelogs checked, nothing should break except sentry, since:
> Sentry Python 2.0 is now only compatible with self-hosted Sentry v20.6.0 and above

Development setup:
* Removed creation of the `.venv` Python virtual environment from the `setup-dev.sh` script, it is created automatically by `uv`.