### PR TITLE
Do not persist PROMETHEUS_MULTIPROC_DIR

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/envs/prod/Dockerfile
+++ b/{{cookiecutter.repostory_name}}/app/envs/prod/Dockerfile
@@ -63,4 +63,9 @@ RUN grep psycopg uv.lock && apk add --no-cache libpq || true
 RUN grep Pillow uv.lock && apk add --no-cache jpeg tiff zlib libwebp || true
 {% endif %}
 
+{% if cookiecutter.monitoring == "y" %}
+ENV PROMETHEUS_MULTIPROC_DIR=/tmp/prometheus-metrics
+RUN mkdir -p "$PROMETHEUS_MULTIPROC_DIR"
+{% endif %}
+
 CMD ["./entrypoint.sh"]

--- a/{{cookiecutter.repostory_name}}/app/envs/prod/entrypoint.sh
+++ b/{{cookiecutter.repostory_name}}/app/envs/prod/entrypoint.sh
@@ -2,7 +2,10 @@
 
 # We assume that WORKDIR is defined in Dockerfile
 
+{% if cookiecutter.monitoring == 'y' %}
 ./prometheus-cleanup.sh
+{% endif %}
+
 PROMETHEUS_EXPORT_MIGRATIONS=0 ./manage.py wait_for_database --timeout 10
 # this seems to be the only place to put this for AWS deployments to pick it up
 PROMETHEUS_EXPORT_MIGRATIONS=0 ./manage.py migrate

--- a/{{cookiecutter.repostory_name}}/app/envs/prod/{% if cookiecutter.monitoring == "y" %}prometheus-cleanup.sh{% endif %}
+++ b/{{cookiecutter.repostory_name}}/app/envs/prod/{% if cookiecutter.monitoring == "y" %}prometheus-cleanup.sh{% endif %}
@@ -1,14 +1,10 @@
 #!/bin/sh
 set -e
 
-if [ -n "$PROMETHEUS_MULTIPROC_DIR" ]; then
-    if [ -d "$PROMETHEUS_MULTIPROC_DIR" ]; then
-        # Delete prometheus live metric files in PROMETHEUS_MULTIPROC_DIR, but not in its subdirectories to not
-        # interfere with other processes.  Note that this is equivalent to what multiprocess.mark_process_dead does,
-        # see https://github.com/prometheus/client_python/blob/master/prometheus_client/multiprocess.py#L159
-        find "$PROMETHEUS_MULTIPROC_DIR" -maxdepth 1 -type f -name 'gauge_live*_*.db' -delete
-    else
-        # Ensure the directory exists
-        mkdir -p "$PROMETHEUS_MULTIPROC_DIR"
-    fi
+if [ -n "${PROMETHEUS_MULTIPROC_DIR:-}" ]; then
+    # Wipe old prometheus metrics files. This is mainly needed for container restarts
+    find "$PROMETHEUS_MULTIPROC_DIR" -maxdepth 1 -type f -name '*.db' -delete
+else
+    # this should normally never happen, cause the env var is being set during docker build phase
+    echo "WARN: PROMETHEUS_MULTIPROC_DIR is not set; skipping metrics cleanup." >&2
 fi

--- a/{{cookiecutter.repostory_name}}/devops/tf/main/files/docker-compose.yml
+++ b/{{cookiecutter.repostory_name}}/devops/tf/main/files/docker-compose.yml
@@ -8,22 +8,10 @@ services:
     env_file: ./.env
     healthcheck:
       test: ["CMD", "./healthcheck.py", "/var/run/gunicorn/gunicorn.sock"]
-    {% if cookiecutter.monitoring == 'y' %}
-    environment:
-      # Add this variable to all containers that should dump Prometheus metrics.  Each container besides this one
-      # should use a different subdirectory of /prometheus-multiproc-dir, e.g.
-      # - PROMETHEUS_MULTIPROC_DIR=/prometheus-multiproc-dir/other-container
-      # Don't forget to also mount the prometheus-metrics volume in other containers too.
-      - PROMETHEUS_MULTIPROC_DIR=/prometheus-multiproc-dir
-    {% endif %}
     volumes:
       - backend-static:/root/src/static
       - gunicorn-socket:/var/run/gunicorn
       - ./media:/root/src/media
-    {% if cookiecutter.monitoring == 'y' %}
-      # Add this mount to each container that should dump Prometheus metrics.
-      - ./prometheus-metrics:/prometheus-multiproc-dir
-    {% endif %}
     logging: &app_logging
       driver: awslogs
       options:

--- a/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
+++ b/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
@@ -74,22 +74,10 @@ services:
     init: true
     restart: unless-stopped
     env_file: ./.env
-    {% if cookiecutter.monitoring == 'y' %}
-    environment:
-      # Add this variable to all containers that should dump Prometheus metrics.  Each container besides this one
-      # should use a different subdirectory of /prometheus-multiproc-dir, e.g.
-      # - PROMETHEUS_MULTIPROC_DIR=/prometheus-multiproc-dir/other-container
-      # Don't forget to also mount the prometheus-metrics volume in other containers too.
-      - PROMETHEUS_MULTIPROC_DIR=/prometheus-multiproc-dir
-    {% endif %}
     volumes:
       - backend-static:/root/src/static
       - gunicorn-socket:/var/run/gunicorn
       - ./media:/root/src/media
-      {% if cookiecutter.monitoring == 'y' %}
-      # Add this mount to each container that should dump Prometheus metrics.
-      - ./prometheus-metrics:/prometheus-multiproc-dir
-      {% endif %}
     depends_on:
       - redis
       - db
@@ -106,14 +94,7 @@ services:
     env_file: ./.env
     environment:
       - DEBUG=off
-      {% if cookiecutter.monitoring == 'y' %}
-      - PROMETHEUS_MULTIPROC_DIR=/prometheus-multiproc-dir/celery-worker
-      {% endif %}
     command: ./celery-entrypoint.sh
-    {% if cookiecutter.monitoring == 'y' %}
-    volumes:
-      - ./prometheus-metrics:/prometheus-multiproc-dir
-    {% endif %}
     tmpfs: /run
     depends_on:
       - redis


### PR DESCRIPTION
Store prometheus metrics in a container-local folder instead of mounting
a host directory.
The $PROMETHEUS_MULTIPROC_DIR is a runtime directory for storing metrics
accumulated for a current process. It is not meant to be persisted
long-term. Prometheus itself is engineered with outages in mind and
storing .db for already dead processes does not bring any value (but
does lead to infinitely growing folders on productions servers).
