### PR TITLE
Set up PROMETHEUS_MULTIPROC_DIR cleanup

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/envs/prod/entrypoint.sh
+++ b/{{cookiecutter.repostory_name}}/app/envs/prod/entrypoint.sh
@@ -2,9 +2,6 @@
 
 # We assume that WORKDIR is defined in Dockerfile
 
-{% if cookiecutter.monitoring %}
-./prometheus-cleanup.sh
-{% endif %}
 PROMETHEUS_EXPORT_MIGRATIONS=0 ./manage.py wait_for_database --timeout 10
 # this seems to be the only place to put this for AWS deployments to pick it up
 PROMETHEUS_EXPORT_MIGRATIONS=0 ./manage.py migrate

--- a/{{cookiecutter.repostory_name}}/app/envs/prod/{% if cookiecutter.use_celery %}celery-entrypoint.sh{% endif %}
+++ b/{{cookiecutter.repostory_name}}/app/envs/prod/{% if cookiecutter.use_celery %}celery-entrypoint.sh{% endif %}
@@ -1,8 +1,6 @@
 #!/bin/sh
 set -eu
 
-./prometheus-cleanup.sh
-
 # below we define two workers types (each may have any concurrency);
 # each worker may have its own settings
 WORKERS="master worker"

--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/{% if cookiecutter.monitoring %}metrics.py{% endif %}
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/{% if cookiecutter.monitoring %}metrics.py{% endif %}
@@ -1,6 +1,7 @@
 import glob
 import os
 
+from pathlib import Path
 import prometheus_client
 {% if cookiecutter.use_celery %}
 from django.conf import settings
@@ -8,23 +9,16 @@ from django.conf import settings
 from django.http import HttpResponse
 from django_prometheus.exports import ExportToDjangoView
 from prometheus_client import REGISTRY, multiprocess
+from prometheus_client.multiprocess import FlockMultiProcessCollector
 
 {% if cookiecutter.use_celery %}
 from ..celery import get_num_tasks_in_queue, num_tasks_in_queue
 {% endif %}
 
 
-class RecursiveMultiProcessCollector(multiprocess.MultiProcessCollector):
-    """A multiprocess collector that scans the directory recursively"""
-
-    def collect(self):
-        files = glob.glob(os.path.join(self._path, "**/*.db"), recursive=True)
-        return self.merge(files, accumulate=True)
-
-
-if is_multiprocess := bool(os.environ.get("PROMETHEUS_MULTIPROC_DIR")):
+if multiproc_dir := os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
     registry = prometheus_client.CollectorRegistry()
-    RecursiveMultiProcessCollector(registry)
+    collector = FlockMultiProcessCollector(registry)
 else:
     registry = REGISTRY
 
@@ -37,7 +31,12 @@ def metrics_view(request):
         num_tasks_in_queue.labels(queue.name).set(get_num_tasks_in_queue(queue.name))
     {% endif %}
 
-    if is_multiprocess:
+    if multiproc_dir:
+        multiproc_path = Path(multiproc_dir)
+        folders_to_cleanup = [multiproc_path] + [f for f in multiproc_path.iterdir() if f.is_dir()]
+        for folder in folders_to_cleanup:
+            collector.cleanup(folder)
+
         return HttpResponse(
             prometheus_client.generate_latest(registry),
             content_type=prometheus_client.CONTENT_TYPE_LATEST,

--- a/{{cookiecutter.repostory_name}}/deploy.sh
+++ b/{{cookiecutter.repostory_name}}/deploy.sh
@@ -24,6 +24,9 @@ if [ -n "$SERVICES" ]; then
 fi
 # start the app container only in order to perform migrations
 docker compose run --rm app sh -c "python manage.py wait_for_database --timeout 10; python manage.py migrate"
+{% if cookiecutter.monitoring %}
+docker compose run --rm app sh prometheus-cleanup.sh
+{% endif %}
 
 # start everything
 docker compose up -d

--- a/{{cookiecutter.repostory_name}}/devops/tf/main/files/docker-compose.yml
+++ b/{{cookiecutter.repostory_name}}/devops/tf/main/files/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       # - PROMETHEUS_MULTIPROC_DIR=/prometheus-multiproc-dir/other-container
       # Don't forget to also mount the prometheus-metrics volume in other containers too.
       - PROMETHEUS_MULTIPROC_DIR=/prometheus-multiproc-dir
+      - PROMETHEUS_USE_FLOCK=1  # this needs to be added to each and every container running this same image/codebase, otherwise things will break
     {% endif %}
     volumes:
       - backend-static:/var/static

--- a/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
+++ b/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
@@ -81,6 +81,7 @@ services:
       # - PROMETHEUS_MULTIPROC_DIR=/prometheus-multiproc-dir/other-container
       # Don't forget to also mount the prometheus-metrics volume in other containers too.
       - PROMETHEUS_MULTIPROC_DIR=/prometheus-multiproc-dir
+      - PROMETHEUS_USE_FLOCK=1  # this needs to be added to each and every container running this same image/codebase, otherwise things will break
     {% endif %}
     volumes:
       - backend-static:/var/static
@@ -108,6 +109,7 @@ services:
       - DEBUG=off
       {% if cookiecutter.monitoring %}
       - PROMETHEUS_MULTIPROC_DIR=/prometheus-multiproc-dir/celery-worker
+      - PROMETHEUS_USE_FLOCK=1  # this needs to be added to each and every container running this same image/codebase, otherwise things will break
       {% endif %}
     command: ./celery-entrypoint.sh
     {% if cookiecutter.monitoring %}

--- a/{{cookiecutter.repostory_name}}/pyproject.toml
+++ b/{{cookiecutter.repostory_name}}/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "more-itertools~=10.8.0",
     {% if cookiecutter.monitoring %}
     "psutil~=7.2.2",
-    "prometheus-client~=0.24.1",
+    "prometheus-client @ git+https://github.com/reef-technologies/prometheus_client.git@77cda428598193698f53129d2311010d39ae8134",
     "django-prometheus~=2.4.1",
     "django-business-metrics>=1.0.1,<2",
     {% endif %}


### PR DESCRIPTION
Add cleanup of "stale" `*.db` metric files, collapsing them to one `merged_metrics.pkl` file per folder.
This depends on implementation in our fork of `prometheus_client` library: https://github.com/reef-technologies/prometheus_client/pull/1