### PR TITLE
Disable prometheus migrations export

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
@@ -113,7 +113,8 @@ INSTALLED_APPS = [
 ]
 
 {% if cookiecutter.monitoring %}
-PROMETHEUS_EXPORT_MIGRATIONS = env.bool("PROMETHEUS_EXPORT_MIGRATIONS")
+# Migrations export is disabled due to a [bug in the library](https://github.com/django-commons/django-prometheus/issues/498)
+PROMETHEUS_EXPORT_MIGRATIONS = False
 {% if cookiecutter.monitor_view_execution_time_in_djagno %}
 PROMETHEUS_LATENCY_BUCKETS = (
     0.008,


### PR DESCRIPTION
Migration exports lead to infinitely growing cardinality metrics when
using prometheus in the multiprocess mode. Disabling until the issue is
addressed in the library code

See:
https://github.com/django-commons/django-prometheus/issues/498

and:
https://github.com/django-commons/django-prometheus/pull/499
