### PR TITLE
feat: Add coverage to tests

### DIFF
--- a/{{cookiecutter.repostory_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.repostory_name}}/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [master, main]
 
-env:
-  ENV_FILL_MISSING_VALUES: 1
-
 jobs:
 {% if cookiecutter.ci_use_linter %}
   linter:
@@ -49,6 +46,9 @@ jobs:
   test:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -67,6 +67,17 @@ jobs:
         run: uv tool install --with pyyaml nox
       - name: Run unit tests
         run: uvx nox -vs test
+      - name: Coverage comment on PR
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: MishaKav/pytest-coverage-comment@dd5b80bde6d16941f336518e92929e89069d8451  # v1.7.2
+        with:
+          pytest-xml-coverage-path: ./app/src/coverage.xml
+          coverage-path-prefix: app/src/{{cookiecutter.django_project_name}}/
+          title: Coverage Report
+          badge-title: Coverage
+          hide-badge: false
+          hide-report: false
+          report-only-changed-files: false
       - name: Stop dockerized services
         if: success() || failure()
         run: docker compose down -v

--- a/{{cookiecutter.repostory_name}}/noxfile.py
+++ b/{{cookiecutter.repostory_name}}/noxfile.py
@@ -163,6 +163,10 @@ def test(session):
             "-vv",
             "-n",
             "auto",
+            "--cov={{cookiecutter.django_project_name}}",
+            "--cov-config=../../pyproject.toml",
+            "--cov-report=term-missing",
+            "--cov-report=xml",
             "{{cookiecutter.django_project_name}}",
             *session.posargs,
         )

--- a/{{cookiecutter.repostory_name}}/pyproject.toml
+++ b/{{cookiecutter.repostory_name}}/pyproject.toml
@@ -74,6 +74,7 @@ distribution = false
 [dependency-groups]
 test = [
     'pytest',
+    'pytest-cov',
     'pytest-django',
     'pytest-xdist',
     {% if cookiecutter.use_channels %}
@@ -122,3 +123,26 @@ ignore = [
 [tool.codespell]
 skip = '*.min.js,*.lock,*/monitoring_certs/*'
 ignore-words-list = 'datas'
+
+[tool.coverage.run]
+source = ["{{cookiecutter.django_project_name}}"]
+branch = true
+omit = [
+    "*/migrations/*",
+    "*/tests/*",
+    "*/management/commands/*",
+    "{{cookiecutter.django_project_name}}/settings.py",
+    "{{cookiecutter.django_project_name}}/asgi.py",
+    "{{cookiecutter.django_project_name}}/wsgi.py",
+    {% if cookiecutter.observability %}
+    "{{cookiecutter.django_project_name}}/otel.py",
+    {% endif %}
+    {% if cookiecutter.use_celery %}
+    "{{cookiecutter.django_project_name}}/celery.py",
+    {% endif %}
+    "manage.py",
+]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false


### PR DESCRIPTION
- Coverage is now displayed in the test summary.
- Coverage is reported in the PR via github-actions.
- Fixed tests failing on projects freshly created from the template.

Issue: RT-6

Example comment generated by git action: https://github.com/reef-technologies/cookiecutter-rt-django-test-app/pull/1#issuecomment-4670150490