### PR TITLE
refactor: DRY OTel env vars in compose files via YAML anchors

### DIFF
--- a/{{cookiecutter.repostory_name}}/devops/tf/main/files/docker-compose.yml
+++ b/{{cookiecutter.repostory_name}}/devops/tf/main/files/docker-compose.yml
@@ -1,5 +1,17 @@
 version: '3.7'
 
+{% if cookiecutter.observability %}
+x-otel-common-envs: &otel-common-envs
+  OTEL_SERVICE_NAMESPACE: $${OTEL_SERVICE_NAMESPACE:-{{cookiecutter.repostory_name}}}
+  OTEL_DEPLOYMENT_ENVIRONMENT: $${OTEL_DEPLOYMENT_ENVIRONMENT:-production}
+
+x-otel-app-envs: &otel-app-envs
+  <<: *otel-common-envs
+  OTEL_EXPORTER_OTLP_ENDPOINT: http://alloy:4318
+  OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
+  OTEL_SERVICE_INSTANCE_ID: $${OTEL_SERVICE_INSTANCE_ID:-}
+{% endif %}
+
 services:
   app:
     image: ${ecr_base_url}/${ecr_image}
@@ -13,18 +25,14 @@ services:
       {% if cookiecutter.monitoring %}
       # Add this variable to all containers that should dump Prometheus metrics.  Each container besides this one
       # should use a different subdirectory of /prometheus-multiproc-dir, e.g.
-      # - PROMETHEUS_MULTIPROC_DIR=/prometheus-multiproc-dir/other-container
+      # PROMETHEUS_MULTIPROC_DIR: /prometheus-multiproc-dir/other-container
       # Don't forget to also mount the prometheus-metrics volume in other containers too.
-      - PROMETHEUS_MULTIPROC_DIR=/prometheus-multiproc-dir
-      - PROMETHEUS_USE_FLOCK=1  # this needs to be added to each and every container running this same image/codebase, otherwise things will break
+      PROMETHEUS_MULTIPROC_DIR: /prometheus-multiproc-dir
+      PROMETHEUS_USE_FLOCK: "1"  # this needs to be added to each and every container running this same image/codebase, otherwise things will break
       {% endif %}
       {% if cookiecutter.observability %}
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
-      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-      - OTEL_SERVICE_NAMESPACE=$${OTEL_SERVICE_NAMESPACE:-{{cookiecutter.repostory_name}}}
-      - OTEL_SERVICE_NAME=app
-      - OTEL_SERVICE_INSTANCE_ID=$${OTEL_SERVICE_INSTANCE_ID:-}
-      - OTEL_DEPLOYMENT_ENVIRONMENT=$${OTEL_DEPLOYMENT_ENVIRONMENT:-production}
+      <<: *otel-app-envs
+      OTEL_SERVICE_NAME: app
       {% endif %}
     {% endif %}
     volumes:
@@ -118,11 +126,10 @@ services:
       test: wget -q --spider http://0.0.0.0:8000/alive/ || exit 1
     {% if cookiecutter.observability %}
     environment:
-      - OTEL_SERVICE_NAMESPACE=$${OTEL_SERVICE_NAMESPACE:-{{cookiecutter.repostory_name}}}
-      - OTEL_SERVICE_NAME=nginx
-      - OTEL_SERVICE_INSTANCE_ID=$${OTEL_SERVICE_INSTANCE_ID:-prod-1}
-      - OTEL_SERVICE_VERSION=$${GIT_SHA:-unknown}
-      - OTEL_DEPLOYMENT_ENVIRONMENT=$${OTEL_DEPLOYMENT_ENVIRONMENT:-production}
+      <<: *otel-common-envs
+      OTEL_SERVICE_NAME: nginx
+      OTEL_SERVICE_INSTANCE_ID: $${OTEL_SERVICE_INSTANCE_ID:-prod-1}
+      OTEL_SERVICE_VERSION: $${GIT_SHA:-unknown}
     {% endif %}
     depends_on:
       - app

--- a/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
+++ b/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
@@ -1,5 +1,17 @@
 version: '3.7'
 
+{% if cookiecutter.observability %}
+x-otel-common-envs: &otel-common-envs
+  OTEL_SERVICE_NAMESPACE: ${OTEL_SERVICE_NAMESPACE:-{{cookiecutter.repostory_name}}}
+  OTEL_DEPLOYMENT_ENVIRONMENT: ${OTEL_DEPLOYMENT_ENVIRONMENT:-production}
+
+x-otel-app-envs: &otel-app-envs
+  <<: *otel-common-envs
+  OTEL_EXPORTER_OTLP_ENDPOINT: http://alloy:4318
+  OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
+  OTEL_SERVICE_INSTANCE_ID: ${OTEL_SERVICE_INSTANCE_ID:-}
+{% endif %}
+
 services:
   redis:
     {% if cookiecutter.use_valkey %}
@@ -81,18 +93,14 @@ services:
       {% if cookiecutter.monitoring %}
       # Add this variable to all containers that should dump Prometheus metrics.  Each container besides this one
       # should use a different subdirectory of /prometheus-multiproc-dir, e.g.
-      # - PROMETHEUS_MULTIPROC_DIR=/prometheus-multiproc-dir/other-container
+      # PROMETHEUS_MULTIPROC_DIR: /prometheus-multiproc-dir/other-container
       # Don't forget to also mount the prometheus-metrics volume in other containers too.
-      - PROMETHEUS_MULTIPROC_DIR=/prometheus-multiproc-dir
-      - PROMETHEUS_USE_FLOCK=1  # this needs to be added to each and every container running this same image/codebase, otherwise things will break
+      PROMETHEUS_MULTIPROC_DIR: /prometheus-multiproc-dir
+      PROMETHEUS_USE_FLOCK: "1"  # this needs to be added to each and every container running this same image/codebase, otherwise things will break
       {% endif %}
       {% if cookiecutter.observability %}
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
-      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-      - OTEL_SERVICE_NAMESPACE=${OTEL_SERVICE_NAMESPACE:-{{cookiecutter.repostory_name}}}
-      - OTEL_SERVICE_NAME=app
-      - OTEL_SERVICE_INSTANCE_ID=${OTEL_SERVICE_INSTANCE_ID:-}
-      - OTEL_DEPLOYMENT_ENVIRONMENT=${OTEL_DEPLOYMENT_ENVIRONMENT:-production}
+      <<: *otel-app-envs
+      OTEL_SERVICE_NAME: app
       {% endif %}
     {% endif %}
     volumes:
@@ -121,18 +129,14 @@ services:
     restart: unless-stopped
     env_file: ./.env
     environment:
-      - DEBUG=off
+      DEBUG: "off"
       {% if cookiecutter.monitoring %}
-      - PROMETHEUS_MULTIPROC_DIR=/prometheus-multiproc-dir/celery-worker
-      - PROMETHEUS_USE_FLOCK=1  # this needs to be added to each and every container running this same image/codebase, otherwise things will break
+      PROMETHEUS_MULTIPROC_DIR: /prometheus-multiproc-dir/celery-worker
+      PROMETHEUS_USE_FLOCK: "1"  # this needs to be added to each and every container running this same image/codebase, otherwise things will break
       {% endif %}
       {% if cookiecutter.observability %}
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
-      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-      - OTEL_SERVICE_NAMESPACE=${OTEL_SERVICE_NAMESPACE:-{{cookiecutter.repostory_name}}}
-      - OTEL_SERVICE_NAME=celery
-      - OTEL_SERVICE_INSTANCE_ID=${OTEL_SERVICE_INSTANCE_ID:-}
-      - OTEL_DEPLOYMENT_ENVIRONMENT=${OTEL_DEPLOYMENT_ENVIRONMENT:-production}
+      <<: *otel-app-envs
+      OTEL_SERVICE_NAME: celery
       {% endif %}
     command: ./celery-entrypoint.sh
     {% if cookiecutter.monitoring %}
@@ -154,14 +158,10 @@ services:
     restart: unless-stopped
     env_file: ./.env
     environment:
-      - DEBUG=off
+      DEBUG: "off"
       {% if cookiecutter.observability %}
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
-      - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-      - OTEL_SERVICE_NAMESPACE=${OTEL_SERVICE_NAMESPACE:-{{cookiecutter.repostory_name}}}
-      - OTEL_SERVICE_NAME=celery-beat
-      - OTEL_SERVICE_INSTANCE_ID=${OTEL_SERVICE_INSTANCE_ID:-}
-      - OTEL_DEPLOYMENT_ENVIRONMENT=${OTEL_DEPLOYMENT_ENVIRONMENT:-production}
+      <<: *otel-app-envs
+      OTEL_SERVICE_NAME: celery-beat
       {% endif %}
     command: nice celery -A {{cookiecutter.django_project_name}} beat -l INFO --schedule /tmp/celerybeat-schedule -f /tmp/logs/celery-beat.log
     volumes:
@@ -208,13 +208,12 @@ services:
       start_period: 20s
       timeout: 10s
     environment:
-      - NGINX_HOST=${NGINX_HOST}
+      NGINX_HOST: ${NGINX_HOST}
       {% if cookiecutter.observability %}
-      - OTEL_SERVICE_NAMESPACE=${OTEL_SERVICE_NAMESPACE:-{{cookiecutter.repostory_name}}}
-      - OTEL_SERVICE_NAME=nginx
-      - OTEL_SERVICE_INSTANCE_ID=${OTEL_SERVICE_INSTANCE_ID:-prod-1}
-      - OTEL_SERVICE_VERSION=${GIT_SHA:-unknown}
-      - OTEL_DEPLOYMENT_ENVIRONMENT=${OTEL_DEPLOYMENT_ENVIRONMENT:-production}
+      <<: *otel-common-envs
+      OTEL_SERVICE_NAME: nginx
+      OTEL_SERVICE_INSTANCE_ID: ${OTEL_SERVICE_INSTANCE_ID:-prod-1}
+      OTEL_SERVICE_VERSION: ${GIT_SHA:-unknown}
       {% endif %}
     volumes:
       - ./nginx/templates:/etc/nginx/templates


### PR DESCRIPTION
Addresses [review comment](https://github.com/reef-technologies/cookiecutter-rt-django/pull/270#discussion_r3388592974) on #270 — extracts the repeated OTel environment variables into reusable `x-otel-common-envs` / `x-otel-app-envs` anchor sections.

- `x-otel-common-envs` — namespace + deployment environment, shared by every instrumented service (including nginx).
- `x-otel-app-envs` — extends the common set with OTLP endpoint/protocol and instance id for app/celery containers.
- Applied to both `envs/prod/docker-compose.yml` (app, celery-worker, celery-beat, nginx) and `devops/tf/main/files/docker-compose.yml` (app, nginx).
- `environment` sections of affected services converted from list to map syntax (required for YAML merge keys); values like `off`/`1` quoted to keep their string semantics.

Verified by rendering the template with cookiecutter (observability on and off) and running `docker compose config` on the prod file and on a simulated-Terraform-rendered tf file — resolved env sets are identical to the previous list form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)