### PR TITLE
refactor: use django-environ and functools.cache in otel.py

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{% if cookiecutter.observability %}otel.py{% endif %}
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{% if cookiecutter.observability %}otel.py{% endif %}
@@ -20,18 +20,21 @@ process and ``setup_sdk_after_fork(service_name)`` from the ``post_fork`` and
 
 from __future__ import annotations
 
-import os
 import uuid
 from typing import Any
 
+import environ
+
 _NAMESPACE_DEFAULT = "{{cookiecutter.repostory_name}}"
 _ENVIRONMENT_DEFAULT = "production"
+
+env = environ.Env()
 
 _cached_instance_id: str | None = None
 
 
 def _sdk_disabled() -> bool:
-    return os.environ.get("OTEL_SDK_DISABLED", "").lower().strip() == "true"
+    return env.bool("OTEL_SDK_DISABLED", default=False)
 
 
 def _get_or_create_instance_id() -> str:
@@ -50,7 +53,7 @@ def _get_or_create_instance_id() -> str:
     pre-fork master process from being inherited by every worker.
     """
     global _cached_instance_id
-    if env_id := os.environ.get("OTEL_SERVICE_INSTANCE_ID"):
+    if env_id := env.str("OTEL_SERVICE_INSTANCE_ID", default=""):
         return env_id
     if _cached_instance_id is None:
         _cached_instance_id = str(uuid.uuid4())
@@ -68,12 +71,12 @@ def _resource_attributes(service_name: str) -> dict[str, str]:
     ``OTEL_SERVICE_INSTANCE_ID``.
     """
     attrs: dict[str, str] = {
-        "service.namespace": os.environ.get("OTEL_SERVICE_NAMESPACE", _NAMESPACE_DEFAULT),
-        "service.name": os.environ.get("OTEL_SERVICE_NAME", service_name),
-        "deployment.environment.name": os.environ.get("OTEL_DEPLOYMENT_ENVIRONMENT", _ENVIRONMENT_DEFAULT),
+        "service.namespace": env.str("OTEL_SERVICE_NAMESPACE", default=_NAMESPACE_DEFAULT),
+        "service.name": env.str("OTEL_SERVICE_NAME", default=service_name),
+        "deployment.environment.name": env.str("OTEL_DEPLOYMENT_ENVIRONMENT", default=_ENVIRONMENT_DEFAULT),
         "service.instance.id": _get_or_create_instance_id(),
     }
-    if version := os.environ.get("OTEL_SERVICE_VERSION") or os.environ.get("GIT_SHA"):
+    if version := env.str("OTEL_SERVICE_VERSION", default="") or env.str("GIT_SHA", default=""):
         attrs["service.version"] = version
     return attrs
 

--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{% if cookiecutter.observability %}otel.py{% endif %}
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{% if cookiecutter.observability %}otel.py{% endif %}
@@ -20,6 +20,7 @@ process and ``setup_sdk_after_fork(service_name)`` from the ``post_fork`` and
 
 from __future__ import annotations
 
+import functools
 import uuid
 from typing import Any
 
@@ -30,34 +31,29 @@ _ENVIRONMENT_DEFAULT = "production"
 
 env = environ.Env()
 
-_cached_instance_id: str | None = None
-
 
 def _sdk_disabled() -> bool:
     return env.bool("OTEL_SDK_DISABLED", default=False)
 
 
+@functools.cache
 def _get_or_create_instance_id() -> str:
     """Return the ``service.instance.id`` for the current process.
 
     Resolution order:
 
-    1. ``OTEL_SERVICE_INSTANCE_ID`` env var (non-empty) — used as-is, never
-       cached because the environment is process-stable. Provides a manual
-       override.
-    2. A module-cached uuid4 generated on first call inside this process.
+    1. ``OTEL_SERVICE_INSTANCE_ID`` env var (non-empty) — provides a manual
+       override; caching it is safe because the environment is
+       process-stable.
+    2. A uuid4 generated on first call inside this process.
 
-    Because each forked worker holds its own copy of module globals, the
-    second branch yields a distinct uuid4 per worker process. The cache must
-    be cleared in ``setup_sdk_after_fork`` to prevent a value generated in the
-    pre-fork master process from being inherited by every worker.
+    Because each forked worker holds its own copy of the ``functools.cache``
+    state, the second branch yields a distinct uuid4 per worker process. The
+    cache must be cleared in ``setup_sdk_after_fork`` to prevent a value
+    generated in the pre-fork master process from being inherited by every
+    worker.
     """
-    global _cached_instance_id
-    if env_id := env.str("OTEL_SERVICE_INSTANCE_ID", default=""):
-        return env_id
-    if _cached_instance_id is None:
-        _cached_instance_id = str(uuid.uuid4())
-    return _cached_instance_id
+    return env.str("OTEL_SERVICE_INSTANCE_ID", default="") or str(uuid.uuid4())
 
 
 def _resource_attributes(service_name: str) -> dict[str, str]:
@@ -127,8 +123,7 @@ def setup_sdk_after_fork(service_name: str) -> None:
     if _sdk_disabled():
         return
 
-    global _cached_instance_id
-    _cached_instance_id = None
+    _get_or_create_instance_id.cache_clear()
 
     from opentelemetry import trace
     from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter

--- a/{{cookiecutter.repostory_name}}/envs/prod/.env.template
+++ b/{{cookiecutter.repostory_name}}/envs/prod/.env.template
@@ -107,6 +107,9 @@ TEMPO_URL={{cookiecutter.traces_aggregator_url}}
 TEMPO_USER=
 TEMPO_PASSWORD=
 
+# OpenTelemetry SDK — enabled in production by default. Set to true to stop emitting traces.
+OTEL_SDK_DISABLED=false
+
 # Service descriptors — propagated to all OTel signals. Namespace is shared by app/celery/nginx; environment shows up in Grafana dropdowns.
 OTEL_SERVICE_NAMESPACE={{cookiecutter.repostory_name}}
 OTEL_DEPLOYMENT_ENVIRONMENT=production


### PR DESCRIPTION
Addresses two review comments on #270 (combined into one PR because both rewrite `_get_or_create_instance_id`, so separate branches would conflict):

- [environ instead of os.environ](https://github.com/reef-technologies/cookiecutter-rt-django/pull/270#discussion_r3389607737) — `otel.py` now reads all `OTEL_*` vars through `environ.Env()`, same as `settings.py`. `OTEL_SDK_DISABLED` uses `env.bool(..., default=False)` and an explicit `OTEL_SDK_DISABLED=false` default was added to `envs/prod/.env.template` (dev template already had `=true`).
- [functools.cache instead of module global](https://github.com/reef-technologies/cookiecutter-rt-django/pull/270#discussion_r3389791956) — the `_cached_instance_id` global is gone; `_get_or_create_instance_id` is wrapped in `@functools.cache` and `setup_sdk_after_fork` calls `cache_clear()` so each forked worker still gets a fresh uuid4. The env-var override is now cached as well, which is safe because the environment is process-stable.

Verified by rendering the template and exercising the module: bool parsing of `OTEL_SDK_DISABLED`, per-process uuid caching, fresh uuid after `cache_clear()`, env override, and resource attributes all behave as before; ruff check/format pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)