### PR TITLE
fix: ignore non-code-related errors; disable sentry when running management commands

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/src/manage.py
+++ b/{{cookiecutter.repostory_name}}/app/src/manage.py
@@ -5,6 +5,8 @@ import sys
 
 def main():
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{cookiecutter.django_project_name}}.settings")
+    if len(sys.argv) > 1 and sys.argv[1] in {"shell", "shell_plus"}:
+        os.environ["SENTRY_DSN"] = ""
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
@@ -542,6 +542,11 @@ if SENTRY_DSN := env("SENTRY_DSN"):
     sentry_sdk.init(  # type: ignore
         dsn=SENTRY_DSN,
         environment=ENV,
+        ignore_errors=[
+            KeyboardInterrupt,
+            SystemExit,
+            BrokenPipeError,
+        ],
         integrations=[
             DjangoIntegration(),
             {% if cookiecutter.use_celery %}


### PR DESCRIPTION
- Filter operational noise from Sentry: `KeyboardInterrupt`, `SystemExit`, and `BrokenPipeError`
- Disable Sentry for `shell` and `shell_plus` by clearing `SENTRY_DSN` in `manage.py`