### PR TITLE
feat: limit journald on direct deployments

### DIFF
--- a/{{cookiecutter.repostory_name}}/bin/{% if cookiecutter.deployment_type in ['direct', 'vultr'] %}prepare-os.sh{% endif %}
+++ b/{{cookiecutter.repostory_name}}/bin/{% if cookiecutter.deployment_type in ['direct', 'vultr'] %}prepare-os.sh{% endif %}
@@ -2,6 +2,15 @@
 # Copyright 2020, Reef Technologies (reef.pl), All rights reserved.
 set -eux
 
+install -d -m 0755 /etc/systemd/journald.conf.d
+cat >/etc/systemd/journald.conf.d/99-limits.conf <<'EOF'
+[Journal]
+SystemMaxUse=2G
+MaxRetentionSec=1month
+Compress=yes
+EOF
+systemctl restart systemd-journald
+
 sudo ufw allow proto tcp from 172.16.0.0/16 to any port 9100  # nginx getting node-exporter metrics
 
 DOCKER_BIN="$(command -v docker || true)"

--- a/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
+++ b/{{cookiecutter.repostory_name}}/envs/prod/docker-compose.yml
@@ -12,6 +12,11 @@ x-otel-app-envs: &otel-app-envs
   OTEL_SERVICE_INSTANCE_ID: ${OTEL_SERVICE_INSTANCE_ID:-}
 {% endif %}
 
+x-logging: &logging
+  driver: journald
+  options:
+    tag: '{% raw %}{{.Name}}{% endraw %}'
+
 services:
   redis:
     {% if cookiecutter.use_valkey %}
@@ -28,10 +33,8 @@ services:
     restart: unless-stopped
     volumes:
       - ./redis/data:/data
-    logging: &logging
-      driver: journald
-      options:
-        tag: '{% raw %}{{.Name}}{% endraw %}'
+    logging:
+      <<: *logging
 
   db:
     image: postgres:14.0-alpine


### PR DESCRIPTION
Caps systemd journal growth on `direct` and `Vultr` deployments so container logs routed through journald cannot fill the disk.