### PR TITLE
ci: limit GITHUB_TOKEN to contents read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Satisfy CodeQL by setting an explicit workflow permissions block instead of relying on the default token scope.