### PR TITLE
docs: use --force-with-lease for deploy push

### DIFF
--- a/{{cookiecutter.repostory_name}}/README.md
+++ b/{{cookiecutter.repostory_name}}/README.md
@@ -97,7 +97,7 @@ Only `master` branch is used to redeploy an application.
 If one wants to deploy other branch, force may be used to push desired branch to remote's `master`:
 
 ```sh
-git push --force production local-branch-to-deploy:master
+git push --force-with-lease production local-branch-to-deploy:master
 ```
 
 </details>


### PR DESCRIPTION
## Zmiana

W README szablonu instrukcja deployu innego brancha używała `git push --force`, co potrafi bezwarunkowo nadpisać commity wypchnięte przez kogoś innego. Zamieniono na `git push --force-with-lease`, które odmówi pusha, jeśli remote zmienił się od ostatniego fetcha.

Przeszukano całe repo — to było jedyne wystąpienie `--force` w dokumentacji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)