### PR TITLE
fix(deps): bump django-fingerprint-rt to 0.2.2

### DIFF
--- a/{{cookiecutter.repostory_name}}/pyproject.toml
+++ b/{{cookiecutter.repostory_name}}/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "opentelemetry-instrumentation-logging~=0.62b1",
     {% endif %}
     {% if cookiecutter.use_fingerprinting %}
-    "django-fingerprint-rt~=0.2.1",
+    "django-fingerprint-rt~=0.2.2",
     {% endif %}
     {% if cookiecutter.use_channels %}
     "channels[daphne]~=4.3.2",


### PR DESCRIPTION
Pick up the latest patch release of the fingerprinting package in generated projects.