### PR TITLE
fix(metrics): read celery queue length at scrape time

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{% if cookiecutter.use_celery %}celery.py{% endif %}
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{% if cookiecutter.use_celery %}celery.py{% endif %}
@@ -18,7 +18,9 @@ from django_structlog.celery.signals import bind_extra_task_metadata
 from django_structlog.celery.steps import DjangoStructLogInitStep
 from more_itertools import chunked
 {% if cookiecutter.monitoring %}
-from prometheus_client import Gauge, multiprocess
+from prometheus_client import Metric, multiprocess
+from prometheus_client.metrics_core import GaugeMetricFamily
+from prometheus_client.registry import Collector
 {% endif %}
 {% if cookiecutter.observability %}
 from {{cookiecutter.django_project_name}}.otel import instrument_before_fork, setup_sdk_after_fork
@@ -32,14 +34,6 @@ app = Celery("{{cookiecutter.django_project_name}}")
 app.config_from_object("django.conf:settings", namespace="CELERY")
 app.steps["worker"].add(DjangoStructLogInitStep)
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
-
-{% if cookiecutter.monitoring %}
-num_tasks_in_queue = Gauge(
-    "celery_queue_len",
-    "How many tasks are there in a queue",
-    labelnames=("queue",),
-)
-{% endif %}
 
 
 @setup_logging.connect
@@ -70,6 +64,20 @@ def get_tasks_in_queue(queue_name: str) -> list[bytes]:
 def get_num_tasks_in_queue(queue_name: str) -> int:
     with app.pool.acquire(block=True) as conn:
         return conn.default_channel.client.llen(queue_name)
+
+{% if cookiecutter.monitoring %}
+
+class CeleryQueueLenCollector(Collector):
+    def collect(self) -> list[Metric]:
+        metric = GaugeMetricFamily(
+            "celery_queue_len",
+            "How many tasks are there in a queue",
+            labels=["queue"],
+        )
+        for queue in settings.CELERY_TASK_QUEUES:
+            metric.add_metric([queue.name], get_num_tasks_in_queue(queue.name))
+        return [metric]
+{% endif %}
 
 
 def move_tasks(source_queue: str, destination_queue: str, chunk_size: int = 100) -> None:

--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/tests/{% if cookiecutter.use_celery and cookiecutter.monitoring %}test_metrics.py{% endif %}
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/tests/{% if cookiecutter.use_celery and cookiecutter.monitoring %}test_metrics.py{% endif %}
@@ -1,0 +1,17 @@
+from kombu import Queue
+
+from {{cookiecutter.django_project_name}}.celery import CeleryQueueLenCollector
+
+
+def test_celery_queue_len_collector_reads_redis_at_collect_time(monkeypatch, settings):
+    settings.CELERY_TASK_QUEUES = (Queue("celery"), Queue("worker"))
+    monkeypatch.setattr(
+        "{{cookiecutter.django_project_name}}.celery.get_num_tasks_in_queue",
+        {"celery": 0, "worker": 2}.__getitem__,
+    )
+
+    metrics = list(CeleryQueueLenCollector().collect())
+
+    assert len(metrics) == 1
+    samples = {(s.labels["queue"], s.value) for s in metrics[0].samples}
+    assert samples == {("celery", 0.0), ("worker", 2.0)}

--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/{% if cookiecutter.monitoring %}metrics.py{% endif %}
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/{% if cookiecutter.monitoring %}metrics.py{% endif %}
@@ -3,16 +3,13 @@ import os
 
 from pathlib import Path
 import prometheus_client
-{% if cookiecutter.use_celery %}
-from django.conf import settings
-{% endif %}
 from django.http import HttpResponse
 from django_prometheus.exports import ExportToDjangoView
 from prometheus_client import REGISTRY, multiprocess
 from prometheus_client.multiprocess import FlockMultiProcessCollector
 
 {% if cookiecutter.use_celery %}
-from ..celery import get_num_tasks_in_queue, num_tasks_in_queue
+from ..celery import CeleryQueueLenCollector
 {% endif %}
 
 
@@ -22,14 +19,13 @@ if multiproc_dir := os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
 else:
     registry = REGISTRY
 
+{% if cookiecutter.use_celery %}
+registry.register(CeleryQueueLenCollector())
+{% endif %}
+
 
 def metrics_view(request):
     """Exports metrics as a Django view"""
-
-    {% if cookiecutter.use_celery %}
-    for queue in settings.CELERY_TASK_QUEUES:
-        num_tasks_in_queue.labels(queue.name).set(get_num_tasks_in_queue(queue.name))
-    {% endif %}
 
     if multiproc_dir:
         multiproc_path = Path(multiproc_dir)


### PR DESCRIPTION
Multiprocess Gauge values went stale across gunicorn workers, so celery_queue_len could report a high max while Redis was empty.