### PR TITLE
fix(sentry): group exceptions logged via structlog

### DIFF
--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/settings.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import environ
 import structlog
+from structlog_sentry import SentryProcessor
 {% if cookiecutter.observability %}
 from {{cookiecutter.django_project_name}}.otel import add_otel_context_to_structlog, add_otel_resource_to_structlog
 {% endif %}
@@ -434,6 +435,14 @@ LOGGING_CALLSITE_PARAMETERS_PROCESSOR = structlog.processors.CallsiteParameterAd
     structlog.processors.CallsiteParameter.LINENO,
 ])
 
+SENTRY_DSN = env("SENTRY_DSN")
+
+LOGGING_SENTRY_PROCESSOR = SentryProcessor(
+    active=bool(SENTRY_DSN),
+    level=logging.INFO,
+    event_level=logging.ERROR,
+)
+
 LOGGING_FOREIGN_PRE_CHAIN = [
     structlog.stdlib.add_log_level,
     structlog.stdlib.add_logger_name,
@@ -516,6 +525,7 @@ STRUCTLOG_CONFIGURATION: dict[str, Any] = dict(
         LOGGING_CALLSITE_PARAMETERS_PROCESSOR,
         structlog.stdlib.PositionalArgumentsFormatter(),
         structlog.processors.StackInfoRenderer(),
+        LOGGING_SENTRY_PROCESSOR,
         structlog.processors.format_exc_info,
         structlog.processors.UnicodeDecoder(),
         {% if cookiecutter.observability %}
@@ -529,8 +539,24 @@ STRUCTLOG_CONFIGURATION: dict[str, Any] = dict(
 )
 structlog.configure(**STRUCTLOG_CONFIGURATION)
 
+
+def _drop_structlog_duplicates(entry: dict, hint: dict) -> dict | None:
+    """Drop Sentry entries already reported by LOGGING_SENTRY_PROCESSOR.
+
+    structlog events also reach stdlib logging, but with `exc_info` already rendered to a string by
+    `format_exc_info`. The Sentry logging integration would report them a second time, without a
+    stacktrace and with the whole event dict (timestamp included) as the message, which makes Sentry
+    treat every single occurrence as a separate issue. structlog marks such records by setting the
+    `_logger` attribute on them.
+    """
+    record = hint.get("log_record")
+    if isinstance(record, logging.LogRecord) and hasattr(record, "_logger"):
+        return None
+    return entry
+
+
 # Sentry
-if SENTRY_DSN := env("SENTRY_DSN"):
+if SENTRY_DSN:
     import sentry_sdk
     {% if cookiecutter.use_celery %}
     from sentry_sdk.integrations.celery import CeleryIntegration
@@ -542,6 +568,8 @@ if SENTRY_DSN := env("SENTRY_DSN"):
     sentry_sdk.init(  # type: ignore
         dsn=SENTRY_DSN,
         environment=ENV,
+        before_send=_drop_structlog_duplicates,
+        before_breadcrumb=_drop_structlog_duplicates,
         ignore_errors=[
             KeyboardInterrupt,
             SystemExit,

--- a/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/tests/test_settings.py
+++ b/{{cookiecutter.repostory_name}}/app/src/{{cookiecutter.django_project_name}}/{{cookiecutter.django_default_app_name}}/tests/test_settings.py
@@ -1,6 +1,35 @@
+import logging
+from collections.abc import Generator
 from importlib import import_module
 
 import pytest
+import sentry_sdk
+import structlog
+from sentry_sdk.integrations.logging import LoggingIntegration
+
+from ...settings import _drop_structlog_duplicates
+
+
+@pytest.fixture
+def sentry_events(settings) -> Generator[list[dict]]:
+    events: list[dict] = []
+    client = sentry_sdk.Client(
+        dsn="https://public@sentry.invalid/0",
+        transport=events.append,
+        default_integrations=False,
+        integrations=[LoggingIntegration(level=logging.INFO, event_level=logging.ERROR)],
+        before_send=_drop_structlog_duplicates,
+        before_breadcrumb=_drop_structlog_duplicates,
+    )
+    processor = settings.LOGGING_SENTRY_PROCESSOR
+    was_active = processor.active
+    processor.active = True
+    try:
+        with sentry_sdk.isolation_scope() as scope:
+            scope.set_client(client)
+            yield events
+    finally:
+        processor.active = was_active
 
 
 def test__settings__celery_beat_schedule(settings):
@@ -19,3 +48,18 @@ def test__settings__celery_beat_schedule(settings):
 
         if not hasattr(module, task_name):
             pytest.fail(f"The task '{task_name}' does not exist in {module_path}")
+
+
+def test__settings__structlog_exceptions_reach_sentry_with_stacktrace(sentry_events):
+    logger = structlog.get_logger("test")
+
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        logger.exception("task failed")
+
+    assert [
+        (value["type"], value["value"], bool(value["stacktrace"]["frames"]))
+        for event in sentry_events
+        for value in event["exception"]["values"]
+    ] == [("ValueError", "boom", True)]

--- a/{{cookiecutter.repostory_name}}/pyproject.toml
+++ b/{{cookiecutter.repostory_name}}/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "psycopg[binary]~=3.3.2",
     "redis~=7.1.1",
     "sentry-sdk~=2.52.0",
+    "structlog-sentry~=2.2.1",
     "ipython~=9.10.0",
     "parso>=0.8.5",  # for python3.14 support
     "more-itertools~=10.8.0",


### PR DESCRIPTION
## Problem

Exceptions logged through structlog (`logger.exception(...)`, `logger.error(..., exc_info=True)`) reached Sentry as plain message events, and **every single occurrence became a separate issue** - with no exception type, no stacktrace and no local variables.

The chain of causes:

1. `structlog.processors.format_exc_info` sits in the structlog processor chain and replaces `exc_info` with a formatted string.
2. `ProcessorFormatter.wrap_for_formatter` passes only the event dict on to stdlib logging, so `LogRecord.exc_info` is `None` and `record.msg` is the whole event dict.
3. Sentry's `LoggingIntegration` builds an exception from `record.exc_info` ([logging.py#L222](https://github.com/getsentry/sentry-python/blob/master/sentry_sdk/integrations/logging.py)); with `None` it falls back to a message event whose message is `str(record.msg)`.

That message contains the timestamp and every bound kwarg, so it differs on each call - and Sentry groups stacktrace-less message events by their message. Hence a new issue per log line:

```
logger      : myapp
has exception: False
logentry    : {"message": "{'attempt': 1, 'event': 'task failed', 'timestamp': '2026-08-27T14:40:50.253335Z',
               'logger': 'myapp', 'level': 'error', 'pathname': '...', 'lineno': 78,
               'exception': 'Traceback (most recent call last): ...'}"}
record.exc_info: None
```

Logs from libraries that use stdlib logging directly were unaffected - they still produced proper exception events.

Note that moving `format_exc_info` into `ProcessorFormatter(processors=[...])` does **not** help: `record.exc_info` stays `None`, because the blocker is `wrap_for_formatter`, not the processor order.

## Fix

Report those events from structlog itself, using [`structlog-sentry`](https://github.com/kiwicom/structlog-sentry):

- `LOGGING_SENTRY_PROCESSOR` is placed **before** `format_exc_info`, while `exc_info` is still a live exception, so Sentry receives a real stacktrace (and the event dict as the `structlog` context). It honours the existing `ignore_logger(...)` calls, and stays inactive when `SENTRY_DSN` is unset.
- `LoggingIntegration` keeps handling foreign (non-structlog) records exactly as before; its duplicate copies of structlog records are dropped in `before_send` / `before_breadcrumb`.

After the fix, the same two occurrences:

```
- logger='myapp' message='task failed'
    exception=[('ValueError', 'boom 1')] frames=['<module>', 'boom']
- logger='myapp' message='task failed'
    exception=[('ValueError', 'boom 2')] frames=['<module>', 'boom']
```

Both group into one issue, keyed by stacktrace. Errors logged without an exception now carry the plain event (`'plain structlog error'`) as the message instead of the whole dict, so they group correctly too.

## Verification

- New regression test in `test_settings.py` asserts that a structlog-logged exception produces exactly one Sentry event, carrying the exception type and a stacktrace.
- `nox -t crufted_project` (lint + tests, both cookiecutter configs).

Unhandled request/task exceptions were never affected - `DjangoIntegration` and `CeleryIntegration` capture those on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
